### PR TITLE
Feat: 포스트 상세 api 추가

### DIFF
--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -37,16 +37,12 @@ export class PostController {
       totalCount,
     })
   }
-
-  @Roles('anyone')
+  
   @ApiOperation({ summary: '포스트 상세' })
   @ApiParam({ name: 'postId', required: true, description: '포스트 id' })
   @ApiResponse({ type: PostDetailResponse })
   @Get(':postId/detail')
-  async getPostDetail(
-    @Req() req,
-    @Param('postId', ParseIntPipe) postId: number
-  ): Promise<PostDetailResponse> {
+  async getPostDetail(@Param('postId', ParseIntPipe) postId: number): Promise<PostDetailResponse> {
     const postDetail = await this.postService.getPostDetail(postId);
     return PostDetailResponse.from(postDetail);
   }

--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -1,10 +1,11 @@
-import { Body, Controller, Get, Post, Query, Req, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, Param, ParseIntPipe, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PaginationResponse } from 'src/common/pagination/pagination-response';
 import { ApiPaginatedResponse } from 'src/common/pagination/pagination.decorator';
 import { Roles } from 'src/common/roles/roles.decorator';
 import { CreatePostInfoDto } from 'src/dto/create-post-dto';
 import { SortPostList } from 'src/dto/request/sort-post-list.request';
+import { PostDetailResponse } from 'src/dto/response/post-detail.response';
 import { PostListResponse } from 'src/dto/response/post-list.response';
 import { RolesGuard } from 'src/guard/roles.guard';
 import { PostService } from 'src/service/post.service';
@@ -35,5 +36,18 @@ export class PostController {
       options: sortPostList,
       totalCount,
     })
+  }
+
+  @Roles('anyone')
+  @ApiOperation({ summary: '포스트 상세' })
+  @ApiParam({ name: 'postId', required: true, description: '포스트 id' })
+  @ApiResponse({ type: PostDetailResponse })
+  @Get(':postId/detail')
+  async getPostDetail(
+    @Req() req,
+    @Param('postId', ParseIntPipe) postId: number
+  ): Promise<PostDetailResponse> {
+    const postDetail = await this.postService.getPostDetail(postId);
+    return PostDetailResponse.from(postDetail);
   }
 }

--- a/src/dto/get-post-detail.dto.ts
+++ b/src/dto/get-post-detail.dto.ts
@@ -1,0 +1,37 @@
+export class GetPostDetail {
+  memberId!: number;
+  nickname!: string;
+  profileImageUrl!: string;
+  createdAt!: Date;
+  postId!: number;
+  title!: string;
+  content!: string;
+  emojiCount!: number;
+  commentCount!: number;
+  viewCount!: number;
+
+  constructor(
+    memberId: number,
+    nickname: string,
+    profileImageUrl: string,
+    createdAt: Date,
+    postId: number,
+    title: string,
+    content: string,
+    emojiCount: number,
+    commentCount: number,
+    viewCount: number,
+  ) {
+    this.memberId = memberId;
+    this.nickname = nickname;
+    this.profileImageUrl = profileImageUrl;
+    this.createdAt = createdAt;
+    this.postId = postId;
+    this.title = title;
+    this.content = content;
+    this.emojiCount = emojiCount;
+    this.commentCount = commentCount;
+    this.viewCount = viewCount;
+  }
+
+}

--- a/src/dto/get-post-detail.dto.ts
+++ b/src/dto/get-post-detail.dto.ts
@@ -1,3 +1,14 @@
+export class GetPostDetailDto {
+  postDetail!: GetPostDetail;
+  hashTag!: GetHashTagInfo[];
+
+  constructor(postDetail: GetPostDetail, hashTag: GetHashTagInfo[]) {
+    this.postDetail = postDetail;
+    this.hashTag = hashTag;
+  }
+}
+
+
 export class GetPostDetail {
   memberId!: number;
   nickname!: string;
@@ -34,4 +45,13 @@ export class GetPostDetail {
     this.viewCount = viewCount;
   }
 
+}
+
+export class GetHashTagInfo {
+  tagName?: string;
+  color?: string;
+  constructor(tagName: string, color: string) {
+    this.tagName = tagName;
+    this.color = color;
+  }
 }

--- a/src/dto/response/post-detail.response.ts
+++ b/src/dto/response/post-detail.response.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { GetPostDetail } from '../get-post-detail.dto';
+import { GetPostDetail, GetPostDetailDto } from '../get-post-detail.dto';
 
-export class PostDetailResponse {
+export class PostDetail {
   @ApiProperty()
   memberId!: number;
   @ApiProperty()
@@ -47,19 +47,43 @@ export class PostDetailResponse {
     this.viewCount = viewCount;
   }
 
-  static from(getPostDetail: GetPostDetail) {
-    const postDetail = new PostDetailResponse(
-      getPostDetail.memberId,
-      getPostDetail.nickname,
-      getPostDetail.profileImageUrl,
-      getPostDetail.createdAt,
-      getPostDetail.postId,
-      getPostDetail.title,
-      getPostDetail.content,
-      getPostDetail.emojiCount,
-      getPostDetail.commentCount,
-      getPostDetail.viewCount,
+
+}
+export class PostDetailHashTag {
+  @ApiProperty()
+  tagName?: string;
+  @ApiProperty()
+  color?: string;
+  constructor(tagName: string, color: string) {
+    this.tagName = tagName;
+    this.color = color;
+  }
+}
+
+export class PostDetailResponse {
+  @ApiProperty({ type: PostDetail })
+  postDetail!: PostDetail;
+  @ApiProperty({ type: [PostDetailHashTag] })
+  postDetailHashTag!: PostDetailHashTag[];
+
+  constructor(postDetail: PostDetail, postDetailHashTag: PostDetailHashTag[]) {
+    this.postDetail = postDetail;
+    this.postDetailHashTag = postDetailHashTag;
+  }
+
+  static from(getPostDetail: GetPostDetailDto) {
+    const postDetail = new PostDetail(
+      getPostDetail.postDetail.memberId,
+      getPostDetail.postDetail.nickname,
+      getPostDetail.postDetail.profileImageUrl,
+      getPostDetail.postDetail.createdAt,
+      getPostDetail.postDetail.postId,
+      getPostDetail.postDetail.title,
+      getPostDetail.postDetail.content,
+      getPostDetail.postDetail.emojiCount,
+      getPostDetail.postDetail.commentCount,
+      getPostDetail.postDetail.viewCount
     );
-    return postDetail;
+    return new PostDetailResponse(postDetail, getPostDetail.hashTag)
   }
 }

--- a/src/dto/response/post-detail.response.ts
+++ b/src/dto/response/post-detail.response.ts
@@ -1,0 +1,65 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { GetPostDetail } from '../get-post-detail.dto';
+
+export class PostDetailResponse {
+  @ApiProperty()
+  memberId!: number;
+  @ApiProperty()
+  nickname!: string;
+  @ApiProperty()
+  profileImageUrl!: string;
+  @ApiProperty()
+  createdAt!: Date;
+  @ApiProperty()
+  postId!: number;
+  @ApiProperty()
+  title!: string;
+  @ApiProperty()
+  content!: string;
+  @ApiProperty()
+  emojiCount!: number;
+  @ApiProperty()
+  commentCount!: number;
+  @ApiProperty()
+  viewCount!: number;
+
+  constructor(
+    memberId: number,
+    nickname: string,
+    profileImageUrl: string,
+    createdAt: Date,
+    postId: number,
+    title: string,
+    content: string,
+    emojiCount: number,
+    commentCount: number,
+    viewCount: number,
+  ) {
+    this.memberId = memberId;
+    this.nickname = nickname;
+    this.profileImageUrl = profileImageUrl;
+    this.createdAt = createdAt;
+    this.postId = postId;
+    this.title = title;
+    this.content = content;
+    this.emojiCount = emojiCount;
+    this.commentCount = commentCount;
+    this.viewCount = viewCount;
+  }
+
+  static from(getPostDetail: GetPostDetail) {
+    const postDetail = new PostDetailResponse(
+      getPostDetail.memberId,
+      getPostDetail.nickname,
+      getPostDetail.profileImageUrl,
+      getPostDetail.createdAt,
+      getPostDetail.postId,
+      getPostDetail.title,
+      getPostDetail.content,
+      getPostDetail.emojiCount,
+      getPostDetail.commentCount,
+      getPostDetail.viewCount,
+    );
+    return postDetail;
+  }
+}

--- a/src/repository/post.query-repository.ts
+++ b/src/repository/post.query-repository.ts
@@ -79,6 +79,28 @@ export class PostQueryRepository {
 
     return query;
   }
+
+  async getPostDetail(postId: number): Promise<GetPostDetailTuple> {
+    const postDetail = await this.dataSource
+      .createQueryBuilder()
+      .from(Post, 'post')
+      .innerJoin(Member, 'member', 'post.member_id = member.id')
+      .where('post.id = :postId', { postId })
+      .select([
+        'member.id as memberId',
+        'member.nickname as nickname',
+        'member.profile_image_url as profileImageUrl',
+        'post.id as postId',
+        'post.title as title',
+        'post.content as content',
+        'post.emoji_count as emojiCount',
+        'post.comment_count as commentCount',
+        'post.view_count as viewCount',
+        'member.deleted_at as memberDeletedAt'
+      ])
+      .getRawOne()
+    return plainToInstance(GetPostDetailTuple, postDetail);
+  }
 }
 
 export class GetPostListTuple {
@@ -93,4 +115,18 @@ export class GetPostListTuple {
   emojiCount!: number;
   commentCount!: number;
   viewCount!: number;
+}
+
+export class GetPostDetailTuple {
+  memberId!: number;
+  nickname!: string;
+  profileImageUrl!: string;
+  createdAt!: Date;
+  postId!: number;
+  title!: string;
+  content!: string;
+  emojiCount!: number;
+  commentCount!: number;
+  viewCount!: number;
+  memberDeletedAt!: Date;
 }

--- a/src/repository/post.query-repository.ts
+++ b/src/repository/post.query-repository.ts
@@ -4,8 +4,10 @@ import { plainToInstance } from 'class-transformer';
 import { PaginationRequest } from 'src/common/pagination/pagination-request';
 import { ListSortBy } from 'src/entity/common/Enums';
 import { Follow } from 'src/entity/follow.entity';
+import { HashTag } from 'src/entity/hash_tag.entity';
 import { Member } from 'src/entity/member.entity';
 import { Post } from 'src/entity/post.entity';
+import { PostHashTag } from 'src/entity/post_hash_tag.entity';
 import { DataSource } from 'typeorm';
 
 @Injectable()
@@ -101,6 +103,20 @@ export class PostQueryRepository {
       .getRawOne()
     return plainToInstance(GetPostDetailTuple, postDetail);
   }
+
+  async getPostDetailHashTag(postId: number): Promise<GetPostDetailHashTagTuple[]> {
+    const postDetailHashTag = await this.dataSource
+      .createQueryBuilder()
+      .from(HashTag, 'hash_tag')
+      .innerJoin(PostHashTag, 'post_hash_tag', 'post_hash_tag.hash_tag_id = hash_tag.id')
+      .where('post_hash_tag.post_id = :postId', { postId })
+      .select([
+        'hash_tag.tagName as tagName',
+        'hash_tag.color as color'
+      ])
+      .getRawMany()
+    return plainToInstance(GetPostDetailHashTagTuple, postDetailHashTag);
+  }
 }
 
 export class GetPostListTuple {
@@ -129,4 +145,9 @@ export class GetPostDetailTuple {
   commentCount!: number;
   viewCount!: number;
   memberDeletedAt!: Date;
+}
+
+export class GetPostDetailHashTagTuple {
+  tagName: string;
+  color: string;
 }

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -66,17 +66,9 @@ export class PostService {
       throw new GoneException('해당 글 작성자가 존재하지 않습니다.');
     }
 
-    const postHashTagInfo = await this.postHashTagRepository.findBy({ postId });
-    const hashTagInfo = await Promise.all(
-      postHashTagInfo.map(async (postHashTag) => {
-        const hashTag = await this.hashTagRepository.findOneBy({ id: postHashTag.hashTagId });
-        if (hashTag) {
-          return { tagName: hashTag.tagName, color: hashTag.color };
-        }
-        return {};
-      })
-    );
-    return new GetPostDetailDto(postDetailInfo, hashTagInfo);
+    const postDetailHashTagInfo = await this.postQueryRepository.getPostDetailHashTag(postId);
+
+    return new GetPostDetailDto(postDetailInfo, postDetailHashTagInfo);
   }
 
 


### PR DESCRIPTION
### 개요  

포스트 상세 api를 추가했습니다.

### 예상 리뷰시간  

5분

### 상세내용

포스트 상세 및 해시태그 객체 배열을 불러옵니다.

### 특이사항

![image](https://github.com/project-cosmo-sns/cosmos-backend/assets/91358761/67d3730d-1879-423e-b9f3-02df586bf72a)
