### PR TITLE
Feat: 포스트 조회수 증가 api 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -37,6 +37,7 @@ import { PostCommentService } from './service/post-comment.service';
 import { PostCommentController } from './controller/post-comment.controller';
 import { PostComment } from './entity/post_comment.entity';
 import { PostCommentHeart } from './entity/post_comment_heart.entity';
+import { PostView } from './entity/post_view.entity';
 
 @Module({
   imports: [
@@ -56,7 +57,8 @@ import { PostCommentHeart } from './entity/post_comment_heart.entity';
       PostCommentHeart,
       PostHashTag,
       HashTag,
-      Follow
+      Follow,
+      PostView
     ]),
     PassportModule.register({
       session: true,

--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -64,4 +64,13 @@ export class PostController {
   async deletePostInfo(@Req() req, @Param('postId', ParseIntPipe) postId: number): Promise<void> {
     return this.postService.deletePost(postId, req.user.id);
   }
+
+  @Roles('anyone')
+  @ApiOperation({ summary: '포스트 조회수 증가' })
+  @ApiParam({ name: 'postId', required: true, description: '포스트 id' })
+  @Post(':postId/view-count/increase')
+  async increasePostViewCount(@Req() req, @Param('postId', ParseIntPipe) postId: number): Promise<void> {
+    const userId = req.user?.id;
+    return this.postService.increasePostViewCount(postId, userId);
+  }
 }

--- a/src/entity/post.entity.ts
+++ b/src/entity/post.entity.ts
@@ -39,7 +39,7 @@ export class Post {
     this.deletedAt = deletedAt;
   }
 
-  plusCommentViewCount(commentCount: number) {
+  plusCommentCount(commentCount: number) {
     this.commentCount = commentCount + 1;
   }
 

--- a/src/entity/post.entity.ts
+++ b/src/entity/post.entity.ts
@@ -39,7 +39,9 @@ export class Post {
     this.deletedAt = deletedAt;
   }
 
-  plusCount(commentCount: number) {
+  plusCommentViewCount(commentCount: number) {
     this.commentCount = commentCount + 1;
   }
+
+
 }

--- a/src/entity/post.entity.ts
+++ b/src/entity/post.entity.ts
@@ -39,6 +39,10 @@ export class Post {
     this.deletedAt = deletedAt;
   }
 
+  plusPostViewCount(viewCount: number) {
+    this.viewCount = viewCount + 1;
+  }
+
   plusCommentCount(commentCount: number) {
     this.commentCount = commentCount + 1;
   }

--- a/src/service/post-comment.service.ts
+++ b/src/service/post-comment.service.ts
@@ -31,7 +31,7 @@ export class PostCommentService {
     if (post.deletedAt !== null) {
       throw new GoneException('해당 포스트는 삭제되었습니다.');
     }
-    post.plusCount(post.commentCount);
+    post.plusCommentCount(post.commentCount);
     await this.postRepository.save(post);
     await this.postCommentRepository.save({
       postId: postId,

--- a/src/service/post-comment.service.ts
+++ b/src/service/post-comment.service.ts
@@ -32,11 +32,11 @@ export class PostCommentService {
       throw new GoneException('해당 포스트는 삭제되었습니다.');
     }
     post.plusCount(post.commentCount);
+    await this.postRepository.save(post);
     await this.postCommentRepository.save({
       postId: postId,
       memberId: memberId,
       content: content
     })
-    await this.postRepository.save(post);
   }
 }

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -12,6 +12,7 @@ import { PostQueryRepository } from 'src/repository/post.query-repository';
 import { GetPostList } from 'src/dto/get-post-list.dto';
 import { GetPostDetailDto } from 'src/dto/get-post-detail.dto';
 import { ListSortBy } from 'src/entity/common/Enums';
+import { PostView } from 'src/entity/post_view.entity';
 
 @Injectable()
 export class PostService {
@@ -20,6 +21,7 @@ export class PostService {
     @InjectRepository(Member) private readonly memberRepository: Repository<Member>,
     @InjectRepository(HashTag) private readonly hashTagRepository: Repository<HashTag>,
     @InjectRepository(PostHashTag) private readonly postHashTagRepository: Repository<PostHashTag>,
+    @InjectRepository(PostView) private readonly postViewRepository: Repository<PostView>,
     private readonly postQueryRepository: PostQueryRepository,
   ) { }
 
@@ -82,6 +84,21 @@ export class PostService {
     await this.postRepository.save(postInfo);
   }
 
+
+  async increasePostViewCount(postId: number, memberId: number): Promise<void> {
+    const postInfo = await this.postRepository.findOneBy({ id: postId });
+    if (!postInfo) {
+      throw new NotFoundException('해당 포스트를 찾을 수 없습니다.');
+    }
+    if (postInfo.deletedAt) {
+      throw new GoneException('해당 포스트는 삭제되었습니다.');
+    }
+    if (memberId) {
+      await this.postViewRepository.save({ postId, memberId });
+    }
+    postInfo.plusPostViewCount(postInfo.viewCount);
+    await this.postRepository.save(postInfo);
+  }
 
   private async saveHashTags(postId: number, hashTags: HashTagDto[]): Promise<void> {
     await Promise.all(hashTags.map(async (hashTagDto) => {

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -75,7 +75,7 @@ export class PostService {
       throw new NotFoundException('해당 포스트를 찾을 수 없습니다.');
     }
     if (postInfo.memberId !== memberId) {
-      throw new UnauthorizedException('해당 포스트를 작성한 사용자가 아닙니다.');
+      throw new UnauthorizedException('권한이 없습니다.');
     }
 
     postInfo.deletePostInfo(new Date())


### PR DESCRIPTION
### 개요  

포스트 조회수 증가시키는 api를 추가했습니다.

### 예상 리뷰시간  

1분

### 상세내용

로그인하지 않아도 조회수 자체는 증가시키도록 만들었으며, 로그인 했을 시, post_view 테이블에 저장됩니다.

### 특이사항
