### PR TITLE
Feat: 포스트 작성 - 해시태그 api 로직 변경

### DIFF
--- a/src/dto/hash-tag-dto.ts
+++ b/src/dto/hash-tag-dto.ts
@@ -1,7 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsInt, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class HashTagDto {
+  @ApiProperty({
+    description: 'number 혹은 null',
+    example: 'number 혹은 null'
+  })
+  @IsOptional()
+  @IsNumber()
+  hashTagId?: number;
+
   @ApiProperty()
   @IsString()
   tagName!: string;

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -44,6 +44,7 @@ export class PostService {
     })
     await this.saveHashTags(post.id, dto.hashTags);
   }
+
   async getPostList(memberId: number, userGeneration: number, sortPostList: SortPostList) {
     const sortBy = sortPostList.sortBy;
     if (typeof memberId === 'undefined' && (sortBy === ListSortBy.BY_FOLLOW || sortBy === ListSortBy.BY_GENERATION)) {
@@ -108,17 +109,18 @@ export class PostService {
 
   private async saveHashTags(postId: number, hashTags: HashTagDto[]): Promise<void> {
     await Promise.all(hashTags.map(async (hashTagDto) => {
-      let hashTagInfo = await this.hashTagRepository.findOneBy({ tagName: hashTagDto.tagName, color: hashTagDto.color });
-
-      if (!hashTagInfo) {
-        hashTagInfo = await this.hashTagRepository.save({
+      let tagId = hashTagDto.hashTagId;
+      if (!hashTagDto.hashTagId) {
+        const newHashTag = await this.hashTagRepository.save({
           tagName: hashTagDto.tagName,
           color: hashTagDto.color,
         });
+        tagId = newHashTag.id;
       }
+
       await this.postHashTagRepository.save({
-        postId: postId,
-        hashTagId: hashTagInfo.id,
+        postId,
+        hashTagId: tagId,
       });
     }));
   }


### PR DESCRIPTION
### 개요  

포스트 작성할 때, 해시태그 저장 로직을 변경하였습니다.

### 예상 리뷰시간  

3분

### 상세내용

새로운 해시태그 => hashTagId: null
기존 해시태그 => hashTagId: number
이런 방식으로 받아오게 변경하였습니다.

### 특이사항

Request Example :
![image](https://github.com/project-cosmo-sns/cosmos-backend/assets/91358761/68c71af1-1742-42cf-a095-0fa31eeb049b)
