### PR TITLE
Feat: 해시태그 검색 api 추가

### DIFF
--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -5,7 +5,9 @@ import { PaginationResponse } from 'src/common/pagination/pagination-response';
 import { ApiPaginatedResponse } from 'src/common/pagination/pagination.decorator';
 import { Roles } from 'src/common/roles/roles.decorator';
 import { CreatePostInfoDto } from 'src/dto/create-post-dto';
+import { HashTagSearchRequest } from 'src/dto/request/hash-tag-search.request';
 import { SortPostList } from 'src/dto/request/sort-post-list.request';
+import { HashTagSearchResponse } from 'src/dto/response/hash-tag-search.response';
 import { PostCommentListResponse } from 'src/dto/response/post-comment-list.response';
 import { PostDetailResponse } from 'src/dto/response/post-detail.response';
 import { PostListResponse } from 'src/dto/response/post-list.response';
@@ -189,5 +191,15 @@ export class PostController {
         throw new InternalServerErrorException('서버 오류가 발생했습니다.');
       }
     }
+  }
+
+  @ApiOperation({ summary: '해시태그 검색' })
+  @ApiResponse({ type: HashTagSearchResponse })
+  @Get('search/hashTag')
+  async searchHashTag(
+    @Query() hashTagSearchRequest: HashTagSearchRequest
+  ): Promise<HashTagSearchResponse[]> {
+    const hashTagSearchResult = await this.postService.getHashTagSearchInfo(hashTagSearchRequest);
+    return HashTagSearchResponse.from(hashTagSearchResult);
   }
 }

--- a/src/dto/get-hash-tag-search.dto.ts
+++ b/src/dto/get-hash-tag-search.dto.ts
@@ -1,0 +1,10 @@
+import { GetHashTagSearchTuple } from "src/repository/post.query-repository";
+
+export class GetHashTagSearch {
+  tagName!: string;
+  constructor(tagName: string) { this.tagName = tagName; }
+
+  static from(tuple: GetHashTagSearchTuple) {
+    return new GetHashTagSearch(tuple.tagName);
+  }
+}

--- a/src/dto/request/hash-tag-search.request.ts
+++ b/src/dto/request/hash-tag-search.request.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { IsString } from "class-validator";
+
+export class HashTagSearchRequest {
+  @ApiProperty({ description: '검색 단어' })
+  @Type(() => String)
+  @IsString()
+  searchWord!: string;
+}

--- a/src/dto/response/hash-tag-search.response.ts
+++ b/src/dto/response/hash-tag-search.response.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { GetHashTagSearch } from "../get-hash-tag-search.dto";
+
+export class HashTagSearchResponse {
+  @ApiProperty({ isArray: true })
+  tagName!: string;
+  constructor(tagName: string) { this.tagName = tagName; }
+
+  static from(getHashTagSearch: GetHashTagSearch[]) {
+    return getHashTagSearch.map(
+      (hashTags) =>
+        new HashTagSearchResponse(
+          hashTags.tagName
+        )
+    );
+  }
+}

--- a/src/repository/post.query-repository.ts
+++ b/src/repository/post.query-repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { Transform, plainToInstance } from 'class-transformer';
 import { PaginationRequest } from 'src/common/pagination/pagination-request';
+import { HashTagSearchRequest } from 'src/dto/request/hash-tag-search.request';
 import { ListSortBy } from 'src/entity/common/Enums';
 import { Follow } from 'src/entity/follow.entity';
 import { HashTag } from 'src/entity/hash_tag.entity';
@@ -165,6 +166,18 @@ export class PostQueryRepository {
       .andWhere('member.deletedAt IS NULL')
       .andWhere('post_comment.post_id = :postId', { postId });
   }
+
+  async getHashTagSearchList(search: HashTagSearchRequest): Promise<GetHashTagSearchTuple[]> {
+    const searchResult = await this.dataSource
+      .createQueryBuilder()
+      .from(HashTag, 'hash_Tag')
+      .select(['tag_name as tagName'])
+      .where(`tag_name LIKE '%${search.searchWord}%'`)
+      .limit(10)
+      .getRawMany()
+
+    return plainToInstance(GetHashTagSearchTuple, searchResult);
+  }
 }
 
 export class GetPostListTuple {
@@ -211,4 +224,8 @@ export class GetPostCommentTuple {
   createdAt: Date;
   @Transform(({ value }) => Boolean(value))
   isHearted: boolean;
+}
+
+export class GetHashTagSearchTuple {
+  tagName!: string;
 }

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -17,6 +17,8 @@ import { PostComment } from 'src/entity/post_comment.entity';
 import { PostCommentHeart } from 'src/entity/post_comment_heart.entity';
 import { PaginationRequest } from 'src/common/pagination/pagination-request';
 import { GetPostCommentList } from 'src/dto/get-post-comment-list.dto';
+import { HashTagSearchRequest } from 'src/dto/request/hash-tag-search.request';
+import { GetHashTagSearch } from 'src/dto/get-hash-tag-search.dto';
 
 @Injectable()
 export class PostService {
@@ -244,5 +246,11 @@ export class PostService {
     commentInfo.minusCommentHeartCount(commentInfo.heartCount);
     await this.postCommentRepository.save(commentInfo);
     await this.postCommentHeartRepository.remove(commentHeartInfo);
+  }
+
+  async getHashTagSearchInfo(hashTagResult: HashTagSearchRequest) {
+    const hashTagSearchTuples = await this.postQueryRepository.getHashTagSearchList(hashTagResult);
+    const hashTagSearchInfo = hashTagSearchTuples.map((hashTagSearch) => GetHashTagSearch.from(hashTagSearch));
+    return hashTagSearchInfo;
   }
 }


### PR DESCRIPTION
### 개요  

해시태그 검색 api를 추가하였습니다.

### 예상 리뷰시간  

5분

### 상세내용

QueryParam으로 입력받는 'searchWord' 기준으로 검색합니다.
해당 단어가 포함되어 있는 해시태그의 이름을 출력하는데, 정렬 기준 없이 일단 10개 제한을 두었습니다.

### 특이사항

![image](https://github.com/project-cosmo-sns/cosmos-backend/assets/91358761/f8b85d84-dcc9-43c2-ad02-d62d840ebd70)
![image](https://github.com/project-cosmo-sns/cosmos-backend/assets/91358761/03caa146-1f0b-40f5-a02e-92070f4486ec)
