### PR TITLE
Feat: 타 유저 프로필 조회 api 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -40,6 +40,9 @@ import { PostEmoji } from './entity/post_emoji.entity';
 import { FollowController } from './controller/follow.controller';
 import { FollowService } from './service/follow.service';
 import { FollowQueryRepository } from './repository/follow.query-repository';
+import { ProfileController } from './controller/profile.controller';
+import { ProfileService } from './service/profile.service';
+import { ProfileQueryRepository } from './repository/profile.query-repository';
 
 @Module({
   imports: [
@@ -74,6 +77,7 @@ import { FollowQueryRepository } from './repository/follow.query-repository';
     PostController,
     ImageController,
     FollowController,
+    ProfileController,
   ],
   providers: [
     // Service
@@ -85,6 +89,7 @@ import { FollowQueryRepository } from './repository/follow.query-repository';
     PostService,
     ImageService,
     FollowService,
+    ProfileService,
 
     // QueryRepository
     MemberQueryRepository,
@@ -92,6 +97,7 @@ import { FollowQueryRepository } from './repository/follow.query-repository';
     FeedCommentQueryRepository,
     PostQueryRepository,
     FollowQueryRepository,
+    ProfileQueryRepository,
 
     // Strategy
     GithubStrategy,

--- a/src/controller/follow.controller.ts
+++ b/src/controller/follow.controller.ts
@@ -30,7 +30,7 @@ export class FollowController {
   async deleteFollow(
     @Param('memberId', ParseIntPipe) memberId: number,
     @Req() req): Promise<void> {
-    return this.followService.unFollowMember(memberId, req.user.id);
+    return this.followService.unFollowMember(req.user.id, memberId);
   }
 
 

--- a/src/controller/follow.controller.ts
+++ b/src/controller/follow.controller.ts
@@ -19,7 +19,7 @@ export class FollowController {
   async postFollow(
     @Param('memberId', ParseIntPipe) memberId: number,
     @Req() req,): Promise<void> {
-    return this.followService.followMember(memberId, req.user.id);
+    return this.followService.followMember(req.user.id, memberId);
   }
 
   @ApiOperation({ summary: '언팔로우' })

--- a/src/controller/profile.controller.ts
+++ b/src/controller/profile.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Param, ParseIntPipe, Req, UseGuards } from "@nestjs/common";
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { Roles } from "src/common/roles/roles.decorator";
+import { OthersProfileInfoResponse } from "src/dto/response/others-profile-info.response";
+import { RolesGuard } from "src/guard/roles.guard";
+import { ProfileService } from "src/service/profile.service";
+
+@ApiTags('프로필')
+@Controller('profile')
+@UseGuards(RolesGuard)
+export class ProfileController {
+  constructor(private readonly profileService: ProfileService) { }
+
+  @ApiOperation({ summary: '다른 유저 프로필 조회' })
+  @ApiParam({ name: 'memberId', required: true, description: '유저 id' })
+  @ApiResponse({ type: OthersProfileInfoResponse })
+  @Get(':memberId')
+  async getOthersProfileInfo(
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @Req() req): Promise<OthersProfileInfoResponse> {
+    const othersProfileInfo = await this.profileService.getOthersProfileInfo(memberId, req.user.id);
+    return OthersProfileInfoResponse.from(othersProfileInfo);
+  }
+
+}

--- a/src/dto/get-others-profile.ts
+++ b/src/dto/get-others-profile.ts
@@ -8,6 +8,7 @@ export class GetOthersProfileDto {
   introduce!: string;
   followerCount!: number;
   followingCount!: number;
+  isFollowed!: boolean;
 
   constructor(
     memberId: number,
@@ -16,7 +17,8 @@ export class GetOthersProfileDto {
     profileImageUrl: string,
     introduce: string,
     followerCount: number,
-    followingCount: number
+    followingCount: number,
+    isFollowed: boolean,
   ) {
     this.memberId = memberId;
     this.nickname = nickname;
@@ -25,6 +27,7 @@ export class GetOthersProfileDto {
     this.introduce = introduce;
     this.followerCount = followerCount;
     this.followingCount = followingCount;
+    this.isFollowed = isFollowed;
   }
 
   static from(tuple: GetOthersProfileTuple) {
@@ -35,7 +38,8 @@ export class GetOthersProfileDto {
       tuple.profileImageUrl,
       tuple.introduce,
       tuple.followerCount,
-      tuple.followingCount
+      tuple.followingCount,
+      tuple.isFollowed
     );
   }
 }

--- a/src/dto/get-others-profile.ts
+++ b/src/dto/get-others-profile.ts
@@ -1,0 +1,41 @@
+import { GetOthersProfileTuple } from "src/repository/profile.query-repository";
+
+export class GetOthersProfileDto {
+  memberId!: number;
+  nickname!: string;
+  generation!: number;
+  profileImageUrl!: string;
+  introduce!: string;
+  followerCount!: number;
+  followingCount!: number;
+
+  constructor(
+    memberId: number,
+    nickname: string,
+    generation: number,
+    profileImageUrl: string,
+    introduce: string,
+    followerCount: number,
+    followingCount: number
+  ) {
+    this.memberId = memberId;
+    this.nickname = nickname;
+    this.generation = generation;
+    this.profileImageUrl = profileImageUrl;
+    this.introduce = introduce;
+    this.followerCount = followerCount;
+    this.followingCount = followingCount;
+  }
+
+  static from(tuple: GetOthersProfileTuple) {
+    return new GetOthersProfileDto(
+      tuple.memberId,
+      tuple.nickname,
+      tuple.generation,
+      tuple.profileImageUrl,
+      tuple.introduce,
+      tuple.followerCount,
+      tuple.followingCount
+    );
+  }
+}

--- a/src/dto/response/others-profile-info.response.ts
+++ b/src/dto/response/others-profile-info.response.ts
@@ -16,6 +16,8 @@ export class OthersProfileInfoResponse {
   followerCount!: number;
   @ApiProperty()
   followingCount!: number;
+  @ApiProperty()
+  isFollowed!: boolean;
 
   constructor(
     memberId: number,
@@ -24,7 +26,8 @@ export class OthersProfileInfoResponse {
     profileImageUrl: string,
     introduce: string,
     followerCount: number,
-    followingCount: number
+    followingCount: number,
+    isFollowed: boolean
   ) {
     this.memberId = memberId;
     this.nickname = nickname;
@@ -33,6 +36,7 @@ export class OthersProfileInfoResponse {
     this.introduce = introduce;
     this.followerCount = followerCount;
     this.followingCount = followingCount;
+    this.isFollowed = isFollowed;
   }
 
   static from(getOthersProfileDto: GetOthersProfileDto) {
@@ -43,7 +47,8 @@ export class OthersProfileInfoResponse {
       getOthersProfileDto.profileImageUrl,
       getOthersProfileDto.introduce,
       getOthersProfileDto.followerCount,
-      getOthersProfileDto.followingCount
+      getOthersProfileDto.followingCount,
+      getOthersProfileDto.isFollowed
     )
   }
 

--- a/src/dto/response/others-profile-info.response.ts
+++ b/src/dto/response/others-profile-info.response.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { GetOthersProfileDto } from "../get-others-profile";
+
+export class OthersProfileInfoResponse {
+  @ApiProperty()
+  memberId!: number;
+  @ApiProperty()
+  nickname!: string;
+  @ApiProperty()
+  generation!: number;
+  @ApiProperty()
+  profileImageUrl!: string;
+  @ApiProperty()
+  introduce!: string;
+  @ApiProperty()
+  followerCount!: number;
+  @ApiProperty()
+  followingCount!: number;
+
+  constructor(
+    memberId: number,
+    nickname: string,
+    generation: number,
+    profileImageUrl: string,
+    introduce: string,
+    followerCount: number,
+    followingCount: number
+  ) {
+    this.memberId = memberId;
+    this.nickname = nickname;
+    this.generation = generation;
+    this.profileImageUrl = profileImageUrl;
+    this.introduce = introduce;
+    this.followerCount = followerCount;
+    this.followingCount = followingCount;
+  }
+
+  static from(getOthersProfileDto: GetOthersProfileDto) {
+    return new OthersProfileInfoResponse(
+      getOthersProfileDto.memberId,
+      getOthersProfileDto.nickname,
+      getOthersProfileDto.generation,
+      getOthersProfileDto.profileImageUrl,
+      getOthersProfileDto.introduce,
+      getOthersProfileDto.followerCount,
+      getOthersProfileDto.followingCount
+    )
+  }
+
+}

--- a/src/repository/profile.query-repository.ts
+++ b/src/repository/profile.query-repository.ts
@@ -23,14 +23,30 @@ export class ProfileQueryRepository {
         'member.generation as generation',
         'member.profile_image_url as profileImageUrl',
         'member.introduce as introduce',
-        '(SELECT COUNT(*) FROM follow WHERE follow.following_member_id = member.id) AS followingCount',
-        '(SELECT COUNT(*) FROM follow WHERE follow.follower_member_id = member.id) AS followerCount',
         'CASE WHEN follow.following_member_id IS NOT NULL THEN true ELSE false END as isFollowed',
 
       ])
       .where('member.id = :memberId', { memberId })
       .getRawOne()
     return plainToInstance(GetOthersProfileTuple, othersProfile);
+  }
+
+  async getProfileFollowerCount(memberId: number): Promise<number> {
+    const followerCount = await this.dataSource
+      .createQueryBuilder()
+      .from(Follow, 'follow')
+      .where('follow.follower_member_id = :memberId', { memberId })
+      .getCount()
+    return followerCount;
+  }
+
+  async getProfileFollowingCount(memberId: number): Promise<number> {
+    const followingCount = await this.dataSource
+      .createQueryBuilder()
+      .from(Follow, 'follow')
+      .where('follow.following_member_id = :memberId', { memberId })
+      .getCount()
+    return followingCount;
   }
 }
 
@@ -44,4 +60,12 @@ export class GetOthersProfileTuple {
   followingCount!: number;
   @Transform(({ value }) => value === '1')
   isFollowed!: boolean;
+}
+
+export class FollowerCountTuple {
+  followerCount!: number;
+}
+
+export class FollowingCountTuple {
+  followingCount!: number;
 }

--- a/src/repository/profile.query-repository.ts
+++ b/src/repository/profile.query-repository.ts
@@ -1,0 +1,39 @@
+import { Injectable } from "@nestjs/common";
+import { plainToInstance } from "class-transformer";
+import { Follow } from "src/entity/follow.entity";
+import { Member } from "src/entity/member.entity";
+import { DataSource } from "typeorm";
+
+@Injectable()
+export class ProfileQueryRepository {
+  constructor(private readonly dataSource: DataSource) { }
+
+  async getOthersProfileInfo(memberId: number, myMemberId: number): Promise<GetOthersProfileTuple> {
+    const othersProfile = await this.dataSource
+      .createQueryBuilder()
+      .from(Member, 'member')
+      .select([
+        'member.id as memberId',
+        'member.nickname as nickname',
+        'member.generation as generation',
+        'member.profile_image_url as profileImageUrl',
+        'member.introduce as introduce',
+        '(SELECT COUNT(*) FROM follow WHERE follow.following_member_id = member.id) AS followerCount',
+        '(SELECT COUNT(*) FROM follow WHERE follow.follower_member_id = member.id) AS followingCount'
+
+      ])
+      .where('member.id = :memberId', { memberId })
+      .getRawOne()
+    return plainToInstance(GetOthersProfileTuple, othersProfile);
+  }
+}
+
+export class GetOthersProfileTuple {
+  memberId!: number;
+  nickname!: string;
+  generation!: number;
+  profileImageUrl!: string;
+  introduce!: string;
+  followerCount!: number;
+  followingCount!: number;
+}

--- a/src/repository/profile.query-repository.ts
+++ b/src/repository/profile.query-repository.ts
@@ -30,9 +30,6 @@ export class ProfileQueryRepository {
       ])
       .where('member.id = :memberId', { memberId })
       .getRawOne()
-    if (othersProfile) {
-      othersProfile.isFollowed = othersProfile.isFollowed === '1' ? true : false;
-    }
     return plainToInstance(GetOthersProfileTuple, othersProfile);
   }
 }
@@ -45,5 +42,6 @@ export class GetOthersProfileTuple {
   introduce!: string;
   followerCount!: number;
   followingCount!: number;
+  @Transform(({ value }) => value === '1')
   isFollowed!: boolean;
 }

--- a/src/service/profile.service.ts
+++ b/src/service/profile.service.ts
@@ -1,0 +1,24 @@
+import { GoneException, Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { GetOthersProfileDto } from "src/dto/get-others-profile";
+import { Member } from "src/entity/member.entity";
+import { ProfileQueryRepository } from "src/repository/profile.query-repository";
+import { Repository } from "typeorm";
+
+@Injectable()
+export class ProfileService {
+  constructor(
+    @InjectRepository(Member) private readonly memberRepository: Repository<Member>,
+    private readonly profileQueryRepository: ProfileQueryRepository
+  ) { }
+
+  async getOthersProfileInfo(memberId: number, myMemberId: number): Promise<GetOthersProfileDto> {
+    const isDeletedUser = await this.memberRepository.findOneBy({ id: memberId });
+    if (isDeletedUser?.deletedAt !== null) {
+      throw new GoneException('탈퇴한 유저입니다.');
+    }
+    const othersProfileInfo = await this.profileQueryRepository.getOthersProfileInfo(memberId, myMemberId);
+
+    return GetOthersProfileDto.from(othersProfileInfo);
+  }
+}

--- a/src/service/profile.service.ts
+++ b/src/service/profile.service.ts
@@ -20,6 +20,11 @@ export class ProfileService {
       throw new GoneException('탈퇴한 유저입니다.');
     }
     const othersProfileInfo = await this.profileQueryRepository.getOthersProfileInfo(memberId, myMemberId);
+    const othersFollowerCount = await this.profileQueryRepository.getProfileFollowerCount(memberId);
+    const othersFollowingCount = await this.profileQueryRepository.getProfileFollowingCount(memberId);
+
+    othersProfileInfo.followerCount = othersFollowerCount;
+    othersProfileInfo.followingCount = othersFollowingCount;
 
     return GetOthersProfileDto.from(othersProfileInfo);
   }

--- a/src/service/profile.service.ts
+++ b/src/service/profile.service.ts
@@ -2,6 +2,7 @@ import { GoneException, Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { GetOthersProfileDto } from "src/dto/get-others-profile";
 import { Member } from "src/entity/member.entity";
+import { MemberQueryRepository } from "src/repository/member.query-repository";
 import { ProfileQueryRepository } from "src/repository/profile.query-repository";
 import { Repository } from "typeorm";
 
@@ -9,12 +10,13 @@ import { Repository } from "typeorm";
 export class ProfileService {
   constructor(
     @InjectRepository(Member) private readonly memberRepository: Repository<Member>,
+    private readonly memberQueryRepository: MemberQueryRepository,
     private readonly profileQueryRepository: ProfileQueryRepository
   ) { }
 
   async getOthersProfileInfo(memberId: number, myMemberId: number): Promise<GetOthersProfileDto> {
-    const isDeletedUser = await this.memberRepository.findOneBy({ id: memberId });
-    if (isDeletedUser?.deletedAt !== null) {
+    const isDeletedUser = await this.memberQueryRepository.getMemberIsNotDeletedById(memberId);
+    if (!isDeletedUser) {
       throw new GoneException('탈퇴한 유저입니다.');
     }
     const othersProfileInfo = await this.profileQueryRepository.getOthersProfileInfo(memberId, myMemberId);


### PR DESCRIPTION
### 개요  

타 유저 프로필 조회 api를 추가했습니다

### 예상 리뷰시간  

5분

### 상세내용

팔로워 수, 팔로잉 수, 로그인된 member기준 팔로우되어있는지 검증하는 isFollowed 필드를 내려주었습니다.
또한, 팔로우 관련해서 모호한 개념이 있어 POST follow api의 member를 전환하였습니다.

### 특이사항
