### PR TITLE
Refactor: 포스트 응답 수정

### DIFF
--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -39,8 +39,9 @@ export class PostController {
     const userGeneration = req.user?.generation;
     try {
       const { postInfo, totalCount } = await this.postService.getPostList(userId, userGeneration, sortPostList);
+      const postData = postInfo.map((info) => PostListResponse.from(info));
       return PaginationResponse.of({
-        data: PostListResponse.from(postInfo),
+        data: postData,
         options: sortPostList,
         totalCount,
       });

--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -118,8 +118,9 @@ export class PostController {
     @Param('postId', ParseIntPipe) postId: number
   ): Promise<PaginationResponse<PostCommentListResponse>> {
     const { postCommentInfo, totalCount } = await this.postService.getPostCommentList(postId, req.user.id, paginationRequest);
+    const postCommentData = postCommentInfo.map((info) => PostCommentListResponse.from(info));
     return PaginationResponse.of({
-      data: PostCommentListResponse.from(postCommentInfo),
+      data: postCommentData,
       options: paginationRequest,
       totalCount,
     })

--- a/src/dto/get-post-comment-list.dto.ts
+++ b/src/dto/get-post-comment-list.dto.ts
@@ -1,16 +1,10 @@
 import { GetPostCommentTuple } from "src/repository/post.query-repository";
+import { PostCommentDto, PostCommentWriterDto } from 'src/service/post.service';
 
 
 export class GetPostCommentList {
-  memberId!: number;
-  nickname!: string;
-  generation!: number;
-  profileImageUrl!: string;
-  commentId!: number;
-  content!: string;
-  heartCount!: number;
-  createdAt!: Date;
-  isHearted!: boolean;
+  writer: PostCommentWriterDto;
+  comment: PostCommentDto;
 
   constructor(
     memberId: number,
@@ -23,15 +17,19 @@ export class GetPostCommentList {
     createdAt: Date,
     isHearted: boolean,
   ) {
-    this.memberId = memberId;
-    this.nickname = nickname;
-    this.generation = generation;
-    this.profileImageUrl = profileImageUrl;
-    this.commentId = commentId;
-    this.content = content;
-    this.heartCount = heartCount;
-    this.createdAt = createdAt;
-    this.isHearted = isHearted;
+    this.writer = {
+      id: memberId,
+      nickname,
+      generation,
+      profileImageUrl,
+    };
+    this.comment = {
+      id: commentId,
+      content,
+      heartCount,
+      createdAt,
+      isHearted,
+    }
   }
 
   static from(tuple: GetPostCommentTuple) {

--- a/src/dto/get-post-detail.dto.ts
+++ b/src/dto/get-post-detail.dto.ts
@@ -1,3 +1,6 @@
+import { GetPostDetailTuple } from 'src/repository/post.query-repository';
+import { PostDto, PostWriterDto } from 'src/service/post.service';
+
 export class GetPostDetailDto {
   postDetail!: GetPostDetail;
   hashTag!: GetHashTagInfo[];
@@ -10,17 +13,8 @@ export class GetPostDetailDto {
 
 
 export class GetPostDetail {
-  memberId!: number;
-  nickname!: string;
-  generation!: number;
-  profileImageUrl!: string;
-  createdAt!: Date;
-  postId!: number;
-  title!: string;
-  content!: string;
-  emojiCount!: number;
-  commentCount!: number;
-  viewCount!: number;
+  writer: PostWriterDto;
+  post: PostDto;
 
   constructor(
     memberId: number,
@@ -35,17 +29,37 @@ export class GetPostDetail {
     commentCount: number,
     viewCount: number,
   ) {
-    this.memberId = memberId;
-    this.nickname = nickname;
-    this.generation = generation;
-    this.profileImageUrl = profileImageUrl;
-    this.createdAt = createdAt;
-    this.postId = postId;
-    this.title = title;
-    this.content = content;
-    this.emojiCount = emojiCount;
-    this.commentCount = commentCount;
-    this.viewCount = viewCount;
+    this.writer = {
+      id: memberId,
+      nickname,
+      generation,
+      profileImageUrl,
+    };
+    this.post = {
+      id: postId,
+      title,
+      content,
+      emojiCount,
+      commentCount,
+      viewCount,
+      createdAt,
+    };
+  }
+
+  static from(tuple: GetPostDetailTuple) {
+    return new GetPostDetail(
+      tuple.memberId,
+      tuple.nickname,
+      tuple.generation,
+      tuple.profileImageUrl,
+      tuple.createdAt,
+      tuple.postId,
+      tuple.title,
+      tuple.content,
+      tuple.emojiCount,
+      tuple.commentCount,
+      tuple.viewCount,
+    );
   }
 
 }

--- a/src/dto/get-post-list.dto.ts
+++ b/src/dto/get-post-list.dto.ts
@@ -1,18 +1,9 @@
 import { GetPostListTuple } from 'src/repository/post.query-repository';
+import { PostDto, PostWriterDto } from 'src/service/post.service';
 
 export class GetPostList {
-
-  memberId!: number;
-  nickname!: string;
-  generation!: number;
-  profileImageUrl!: string;
-  createdAt!: Date;
-  postId!: number;
-  title!: string;
-  content!: string;
-  emojiCount!: number;
-  commentCount!: number;
-  viewCount!: number;
+  writer: PostWriterDto;
+  post: PostDto;
 
   constructor(
     memberId: number,
@@ -27,17 +18,21 @@ export class GetPostList {
     commentCount: number,
     viewCount: number,
   ) {
-    this.memberId = memberId;
-    this.nickname = nickname;
-    this.generation = generation;
-    this.profileImageUrl = profileImageUrl;
-    this.createdAt = createdAt;
-    this.postId = postId;
-    this.title = title;
-    this.content = content;
-    this.emojiCount = emojiCount;
-    this.commentCount = commentCount;
-    this.viewCount = viewCount;
+    this.writer = {
+      id: memberId,
+      nickname,
+      generation,
+      profileImageUrl,
+    };
+    this.post = {
+      id: postId,
+      title,
+      content,
+      emojiCount,
+      commentCount,
+      viewCount,
+      createdAt,
+    };
   }
 
   static from(tuple: GetPostListTuple) {

--- a/src/dto/response/post-comment-list.response.ts
+++ b/src/dto/response/post-comment-list.response.ts
@@ -1,62 +1,32 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { GetPostCommentList } from '../get-post-comment-list.dto';
+import { PostCommentDto, PostCommentWriterDto} from 'src/service/post.service';
 
 export class PostCommentListResponse {
-  @ApiProperty()
-  memberId!: number;
-  @ApiProperty()
-  nickname!: string;
-  @ApiProperty()
-  generation!: number;
-  @ApiProperty()
-  profileImageUrl!: string;
-  @ApiProperty()
-  commentId!: number;
-  @ApiProperty()
-  content!: string;
-  @ApiProperty()
-  heartCount!: number;
-  @ApiProperty()
-  createdAt!: Date;
-  @ApiProperty()
-  isHearted!: Boolean;
-
-  constructor(
-    memberId: number,
-    nickname: string,
-    generation: number,
-    profileImageUrl: string,
-    commentId: number,
-    content: string,
-    heartCount: number,
-    createdAt: Date,
-    isHearted: boolean,
-  ) {
-    this.memberId = memberId;
-    this.nickname = nickname;
-    this.generation = generation;
-    this.profileImageUrl = profileImageUrl;
-    this.commentId = commentId;
-    this.content = content;
-    this.heartCount = heartCount;
-    this.createdAt = createdAt;
-    this.isHearted = isHearted;
+  @ApiProperty({
+    type: {
+      id: { type: 'number' },
+      nickname: { type: 'string' },
+      generation: { type: 'number' },
+      profileImageUrl: { type: 'string' },
+    },
+  })
+  writer: PostCommentWriterDto;
+  @ApiProperty({
+    type: {
+      id: { type: 'number' },
+      content: { type: 'string' },
+      heartCount: { type: 'number' },
+      isHearted: { type: 'boolean' },
+      createdAt: { type: 'string' },
+    },
+  })
+  comment: PostCommentDto;
+  constructor(writer: PostCommentWriterDto, comment: PostCommentDto) {
+    this.writer = writer;
+    this.comment = comment;
   }
 
-  static from(getPostCommentLists: GetPostCommentList[]) {
-    return getPostCommentLists.map(
-      (commentLists) =>
-        new PostCommentListResponse(
-          commentLists.memberId,
-          commentLists.nickname,
-          commentLists.generation,
-          commentLists.profileImageUrl,
-          commentLists.commentId,
-          commentLists.content,
-          commentLists.heartCount,
-          commentLists.createdAt,
-          commentLists.isHearted
-        )
-    )
+  static from({ writer, comment }: { writer: PostCommentWriterDto; comment: PostCommentDto }) {
+    return new PostCommentListResponse(writer, comment);
   }
 }

--- a/src/dto/response/post-detail.response.ts
+++ b/src/dto/response/post-detail.response.ts
@@ -1,57 +1,34 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { GetPostDetail, GetPostDetailDto } from '../get-post-detail.dto';
+import { PostDto, PostWriterDto } from 'src/service/post.service';
 
 export class PostDetail {
-  @ApiProperty()
-  memberId!: number;
-  @ApiProperty()
-  nickname!: string;
-  @ApiProperty()
-  generation!: number;
-  @ApiProperty()
-  profileImageUrl!: string;
-  @ApiProperty()
-  createdAt!: Date;
-  @ApiProperty()
-  postId!: number;
-  @ApiProperty()
-  title!: string;
-  @ApiProperty()
-  content!: string;
-  @ApiProperty()
-  emojiCount!: number;
-  @ApiProperty()
-  commentCount!: number;
-  @ApiProperty()
-  viewCount!: number;
+  @ApiProperty({
+    type: {
+      id: { type: 'number' },
+      nickname: { type: 'string' },
+      generation: { type: 'number' },
+      profileImageUrl: { type: 'string' },
+    },
+  })
+  writer: PostWriterDto;
+  @ApiProperty({
+    type: {
+      id: { type: 'number' },
+      title: { type: 'string' },
+      content: { type: 'string' },
+      viewCount: { type: 'number' },
+      commentCount: { type: 'number' },
+      emojiCount: { type: 'number' },
+      createdAt: { type: 'string' },
+    },
+  })
+  post: PostDto;
 
-  constructor(
-    memberId: number,
-    nickname: string,
-    generation: number,
-    profileImageUrl: string,
-    createdAt: Date,
-    postId: number,
-    title: string,
-    content: string,
-    emojiCount: number,
-    commentCount: number,
-    viewCount: number,
-  ) {
-    this.memberId = memberId;
-    this.nickname = nickname;
-    this.generation = generation;
-    this.profileImageUrl = profileImageUrl;
-    this.createdAt = createdAt;
-    this.postId = postId;
-    this.title = title;
-    this.content = content;
-    this.emojiCount = emojiCount;
-    this.commentCount = commentCount;
-    this.viewCount = viewCount;
+  constructor(writer: PostWriterDto, post: PostDto) {
+    this.writer = writer;
+    this.post = post;
   }
-
-
 }
 export class PostDetailHashTag {
   @ApiProperty()
@@ -77,17 +54,8 @@ export class PostDetailResponse {
 
   static from(getPostDetail: GetPostDetailDto) {
     const postDetail = new PostDetail(
-      getPostDetail.postDetail.memberId,
-      getPostDetail.postDetail.nickname,
-      getPostDetail.postDetail.generation,
-      getPostDetail.postDetail.profileImageUrl,
-      getPostDetail.postDetail.createdAt,
-      getPostDetail.postDetail.postId,
-      getPostDetail.postDetail.title,
-      getPostDetail.postDetail.content,
-      getPostDetail.postDetail.emojiCount,
-      getPostDetail.postDetail.commentCount,
-      getPostDetail.postDetail.viewCount
+      getPostDetail.postDetail.writer,
+      getPostDetail.postDetail.post,
     );
     return new PostDetailResponse(postDetail, getPostDetail.hashTag)
   }

--- a/src/dto/response/post-list.response.ts
+++ b/src/dto/response/post-list.response.ts
@@ -1,72 +1,36 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { GetPostList } from '../get-post-list.dto';
+import { PostDto, PostWriterDto } from 'src/service/post.service';
 
 export class PostListResponse {
-  @ApiProperty()
-  memberId!: number;
-  @ApiProperty()
-  nickname!: string;
-  @ApiProperty()
-  generation!: number;
-  @ApiProperty()
-  profileImageUrl!: string;
-  @ApiProperty()
-  createdAt!: Date;
-  @ApiProperty()
-  postId!: number;
-  @ApiProperty()
-  title!: string;
-  @ApiProperty()
-  content!: string;
-  @ApiProperty()
-  emojiCount!: number;
-  @ApiProperty()
-  commentCount!: number;
-  @ApiProperty()
-  viewCount!: number;
+  @ApiProperty({
+    type: {
+      id: { type: 'number' },
+      nickname: { type: 'string' },
+      generation: { type: 'number' },
+      profileImageUrl: { type: 'string' },
+    },
+  })
+  writer: PostWriterDto;
+  @ApiProperty({
+    type: {
+      id: { type: 'number' },
+      title: { type: 'string' },
+      content: { type: 'string' },
+      viewCount: { type: 'number' },
+      commentCount: { type: 'number' },
+      emojiCount: { type: 'number' },
+      createdAt: { type: 'string' },
+    },
+  })
+  post: PostDto;
 
-  constructor(
-    memberId: number,
-    nickname: string,
-    generation: number,
-    profileImageUrl: string,
-    createdAt: Date,
-    postId: number,
-    title: string,
-    content: string,
-    emojiCount: number,
-    commentCount: number,
-    viewCount: number,
-  ) {
-    this.memberId = memberId;
-    this.nickname = nickname;
-    this.generation = generation;
-    this.profileImageUrl = profileImageUrl;
-    this.createdAt = createdAt;
-    this.postId = postId;
-    this.title = title;
-    this.content = content;
-    this.emojiCount = emojiCount;
-    this.commentCount = commentCount;
-    this.viewCount = viewCount;
+  constructor(writer: PostWriterDto, post: PostDto) {
+    this.writer = writer;
+    this.post = post;
   }
 
-  static from(getPostLists: GetPostList[]) {
-    return getPostLists.map(
-      (getPostLists) =>
-        new PostListResponse(
-          getPostLists.memberId,
-          getPostLists.nickname,
-          getPostLists.generation,
-          getPostLists.profileImageUrl,
-          getPostLists.createdAt,
-          getPostLists.postId,
-          getPostLists.title,
-          getPostLists.content,
-          getPostLists.emojiCount,
-          getPostLists.commentCount,
-          getPostLists.viewCount
-        )
-    )
+  static from({ writer, post }: { writer: PostWriterDto; post: PostDto }) {
+    return new PostListResponse(writer, post);
   }
 }

--- a/src/repository/post.query-repository.ts
+++ b/src/repository/post.query-repository.ts
@@ -74,8 +74,8 @@ export class PostQueryRepository {
 
 
     if (sortPostList === ListSortBy.BY_FOLLOW) {
-      query = query.innerJoin(Follow, 'follow', 'following_member_id = member.id')
-        .andWhere('follower_member_id = :memberId', { memberId });
+      query = query.innerJoin(Follow, 'follow', 'follower_member_id = member.id')
+        .andWhere('following_member_id = :memberId', { memberId });
     }
 
     else if (sortPostList === ListSortBy.BY_GENERATION) {

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -37,7 +37,7 @@ export class PostService {
     @InjectRepository(Notification) private readonly notificationRepository: Repository<Notification>,
     private readonly postQueryRepository: PostQueryRepository,
     private readonly memberQueryRepository: MemberQueryRepository,
-  ) {}
+  ) { }
 
   async createPost(memberId: number, dto: CreatePostInfoDto): Promise<void> {
     const member = await this.memberRepository.findOneBy({ id: memberId });
@@ -336,4 +336,21 @@ export class PostService {
       console.error(e);
     }
   }
+}
+
+export class PostWriterDto {
+  id: number;
+  nickname: string;
+  generation: number;
+  profileImageUrl: string;
+}
+
+export class PostDto {
+  id: number;
+  title: string;
+  content: string;
+  viewCount: number;
+  commentCount: number;
+  emojiCount: number;
+  createdAt: Date;
 }

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -10,7 +10,7 @@ import { Repository } from 'typeorm';
 import { SortPostList } from 'src/dto/request/sort-post-list.request';
 import { PostQueryRepository } from 'src/repository/post.query-repository';
 import { GetPostList } from 'src/dto/get-post-list.dto';
-import { GetPostDetailDto } from 'src/dto/get-post-detail.dto';
+import { GetPostDetail, GetPostDetailDto } from 'src/dto/get-post-detail.dto';
 import { ListSortBy, NotificationType } from 'src/entity/common/Enums';
 import { PostView } from 'src/entity/post_view.entity';
 import { PostComment } from 'src/entity/post_comment.entity';
@@ -87,7 +87,8 @@ export class PostService {
 
     const postDetailHashTagInfo = await this.postQueryRepository.getPostDetailHashTag(postId);
 
-    return new GetPostDetailDto(postDetailInfo, postDetailHashTagInfo);
+    const postDetail = GetPostDetail.from(postDetailInfo);
+    return new GetPostDetailDto(postDetail, postDetailHashTagInfo);
   }
 
   async deletePost(postId: number, memberId: number): Promise<void> {

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -354,3 +354,18 @@ export class PostDto {
   emojiCount: number;
   createdAt: Date;
 }
+
+export class PostCommentWriterDto {
+  id: number;
+  nickname: string;
+  generation: number;
+  profileImageUrl: string;
+}
+
+export class PostCommentDto {
+  id: number;
+  content: string;
+  heartCount: number;
+  isHearted: boolean;
+  createdAt: Date;
+}


### PR DESCRIPTION
### 개요  

포스트 목록 조회, 포스트 상세 조회, 포스트 댓글 목록 조회 api들의 응답을 변경하였습니다.

### 예상 리뷰시간  

10분

### 상세내용

포스트 목록, 상세는 writer | post 로 묶여 내려가고,
포스트 댓글 목로은 writer | comment로 묶여 내려가게 설정하였습니다.

### 특이사항

포스트 목록의 팔로우 정렬 기준을 반대로 수정하였습니다.