### PR TITLE
Feat: 포스트 수정 api 추가

### DIFF
--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Delete, Get, GoneException, InternalServerErrorException, NotFoundException, Param, ParseIntPipe, Patch, Post, Query, Req, UnauthorizedException, UseGuards } from '@nestjs/common';
-import { ApiBody, ApiGoneResponse, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { ApiBody, ApiGoneResponse, ApiNotFoundResponse, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import { PaginationRequest } from 'src/common/pagination/pagination-request';
 import { PaginationResponse } from 'src/common/pagination/pagination-response';
 import { ApiPaginatedResponse } from 'src/common/pagination/pagination.decorator';
@@ -63,6 +63,19 @@ export class PostController {
   async getPostDetail(@Param('postId', ParseIntPipe) postId: number): Promise<PostDetailResponse> {
     const postDetail = await this.postService.getPostDetail(postId);
     return PostDetailResponse.from(postDetail);
+  }
+
+  @ApiOperation({ summary: '포스트 수정' })
+  @ApiParam({ name: 'postId', required: true, description: '포스트 id' })
+  @ApiNotFoundResponse({ status: 404, description: '해당 postId값을 가진 포스트가 없거나 삭제된 경우' })
+  @ApiUnauthorizedResponse({ status: 401, description: '포스트 쓴 유저가 아닐 경우' })
+  @Patch(':postId')
+  async modifyPostInfo(
+    @Param('postId', ParseIntPipe) postId: number,
+    @Req() req,
+    @Body() createPostInfo: CreatePostInfoDto,
+  ): Promise<void> {
+    return await this.postService.modifyPost(postId, req.user.id, createPostInfo);
   }
 
   @ApiOperation({ summary: '포스트 삭제' })

--- a/src/dto/hash-tag-dto.ts
+++ b/src/dto/hash-tag-dto.ts
@@ -3,8 +3,8 @@ import { IsInt, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class HashTagDto {
   @ApiProperty({
-    description: 'number 혹은 null',
-    example: 'number 혹은 null'
+    description: 'number 혹은 새로운 태그일 경우 null',
+    example: 'number 혹은 새로운 태그일 경우 null'
   })
   @IsOptional()
   @IsNumber()

--- a/src/entity/member.entity.ts
+++ b/src/entity/member.entity.ts
@@ -53,24 +53,6 @@ export class Member {
     this.introduce = introduce;
   }
 
-  // setMyPageInfo(
-  //   nickname?: string,
-  //   profileImageUrl?: string,
-  //   position?: string,
-  //   career?: number,
-  //   introduce?: string,
-  //   stack?: string,
-  //   link?: string,
-  // ) {
-  //   this.nickname = nickname;
-  //   this.profileImageUrl = profileImageUrl;
-  //   this.position = position;
-  //   this.career = career;
-  //   this.introduce = introduce;
-  //   this.stack = stack;
-  //   this.link = link;
-  // }
-
   setDelete(deletedAt: Date) {
     this.externalId = null;
     this.deletedAt = deletedAt;

--- a/src/entity/post.entity.ts
+++ b/src/entity/post.entity.ts
@@ -58,4 +58,10 @@ export class Post {
   minusEmojiCount(emojiCount: number) {
     this.emojiCount = emojiCount - 1;
   }
+
+  setPostInfo(category: string, title: string, content: string) {
+    this.category = category;
+    this.title = title;
+    this.content = content;
+  }
 }

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -98,6 +98,23 @@ export class PostService {
     return new GetPostDetailDto(postDetail, postDetailHashTagInfo);
   }
 
+  async modifyPost(postId: number, memberId: number, dto: CreatePostInfoDto): Promise<void> {
+    const postInfo = await this.postRepository.findOneBy({ id: postId });
+    if (!postInfo || postInfo.deletedAt !== null) {
+      throw new NotFoundException('해당 포스트가 없거나 삭제되었습니다.');
+    }
+    if (postInfo.memberId !== memberId) {
+      throw new UnauthorizedException('권한이 없습니다.');
+    }
+    const hashTags = await this.postHashTagRepository.findBy({ postId });
+
+    postInfo.setPostInfo(dto.category, dto.title, dto.content);
+    await this.postRepository.save(postInfo);
+
+    await Promise.all(hashTags.map(tag => this.postHashTagRepository.remove(tag)));
+    await this.saveHashTags(postInfo.id, dto.hashTags);
+  }
+
   async deletePost(postId: number, memberId: number): Promise<void> {
     const postInfo = await this.postRepository.findOneBy({ id: postId });
     if (!postInfo) {
@@ -166,26 +183,6 @@ export class PostService {
     }
     postInfo.plusPostViewCount(postInfo.viewCount);
     await this.postRepository.save(postInfo);
-  }
-
-  private async saveHashTags(postId: number, hashTags: HashTagDto[]): Promise<void> {
-    await Promise.all(
-      hashTags.map(async (hashTagDto) => {
-        let tagId = hashTagDto.hashTagId;
-        if (!hashTagDto.hashTagId) {
-          const newHashTag = await this.hashTagRepository.save({
-            tagName: hashTagDto.tagName,
-            color: hashTagDto.color,
-          });
-          tagId = newHashTag.id;
-        }
-
-        await this.postHashTagRepository.save({
-          postId,
-          hashTagId: tagId,
-        });
-      }),
-    );
   }
 
   async getPostCommentList(postId: number, memberId: number, paginationRequest: PaginationRequest) {
@@ -314,6 +311,26 @@ export class PostService {
     const hashTagSearchTuples = await this.postQueryRepository.getHashTagSearchList(hashTagResult);
     const hashTagSearchInfo = hashTagSearchTuples.map((hashTagSearch) => GetHashTagSearch.from(hashTagSearch));
     return hashTagSearchInfo;
+  }
+
+  private async saveHashTags(postId: number, hashTags: HashTagDto[]): Promise<void> {
+    await Promise.all(
+      hashTags.map(async (hashTagDto) => {
+        let tagId = hashTagDto.hashTagId;
+        if (!hashTagDto.hashTagId) {
+          const newHashTag = await this.hashTagRepository.save({
+            tagName: hashTagDto.tagName,
+            color: hashTagDto.color,
+          });
+          tagId = newHashTag.id;
+        }
+
+        await this.postHashTagRepository.save({
+          postId,
+          hashTagId: tagId,
+        });
+      }),
+    );
   }
 
   private async newPostCommentNotification(receivedMemberId, sendMemberId, postId, commentId) {

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -317,7 +317,7 @@ export class PostService {
     await Promise.all(
       hashTags.map(async (hashTagDto) => {
         let tagId = hashTagDto.hashTagId;
-        if (!hashTagDto.hashTagId) {
+        if (!tagId) {
           const newHashTag = await this.hashTagRepository.save({
             tagName: hashTagDto.tagName,
             color: hashTagDto.color,


### PR DESCRIPTION
### 개요  

포스트 수정 api 추가했습니다

### 예상 리뷰시간  

5분

### 상세내용

❗ [해시태그 수정 로직]
해당 포스트에 있던 해시태그 정보들을 모두 삭제 후,포스트 작성 api 처럼 해시태그들을 검증 후 추가했습니다. 
해시태그 자체의 정보는 삭제하지 않았습니다. (자동완성 기능 때 쓰이지 않는 해시태그가 추천될 수도 있겠네요)


### 특이사항
