### PR TITLE
Feat: 오늘의 질문 api 추가

### DIFF
--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -38,6 +38,7 @@ import { ImageResponse } from 'src/dto/response/image.response';
 import { PostCommentListResponse } from 'src/dto/response/post-comment-list.response';
 import { PostDetailResponse } from 'src/dto/response/post-detail.response';
 import { PostListResponse } from 'src/dto/response/post-list.response';
+import { TodayQuestionResponse } from 'src/dto/response/today-question.response';
 import { RolesGuard } from 'src/guard/roles.guard';
 import { ImageService } from 'src/service/image.service';
 import { PostService } from 'src/service/post.service';
@@ -290,5 +291,12 @@ export class PostController {
 
     const uploadUrl = await this.imageService.createUploadURL(bucket);
     return new ImageResponse(uploadUrl);
+  }
+
+  @ApiOperation({ summary: '오늘의 질문 불러오기' })
+  @Get('today-question')
+  async getTodayQuestion(): Promise<TodayQuestionResponse> {
+    const todayQuestion = await this.postService.getTodayQuestion();
+    return new TodayQuestionResponse(todayQuestion.postId, todayQuestion.question);
   }
 }

--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -297,6 +297,6 @@ export class PostController {
   @Get('today-question')
   async getTodayQuestion(): Promise<TodayQuestionResponse> {
     const todayQuestion = await this.postService.getTodayQuestion();
-    return new TodayQuestionResponse(todayQuestion.postId, todayQuestion.question);
+    return new TodayQuestionResponse(todayQuestion.postId, todayQuestion.title);
   }
 }

--- a/src/dto/response/today-question.response.ts
+++ b/src/dto/response/today-question.response.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TodayQuestionResponse {
+  @ApiProperty()
+  postId!: number;
+  @ApiProperty()
+  question!: string;
+
+  constructor(postId: number, question: string) {
+    this.postId = postId;
+    this.question = question;
+  }
+}

--- a/src/dto/response/today-question.response.ts
+++ b/src/dto/response/today-question.response.ts
@@ -4,10 +4,10 @@ export class TodayQuestionResponse {
   @ApiProperty()
   postId!: number;
   @ApiProperty()
-  question!: string;
+  title!: string;
 
-  constructor(postId: number, question: string) {
+  constructor(postId: number, title: string) {
     this.postId = postId;
-    this.question = question;
+    this.title = title;
   }
 }

--- a/src/repository/post.query-repository.ts
+++ b/src/repository/post.query-repository.ts
@@ -153,7 +153,7 @@ export class PostQueryRepository {
       .where("post.category ='오늘의 질문'")
       .select([
         'post.id as postId',
-        'post.title as question'
+        'post.title as title'
       ])
       .orderBy('RAND()')
       .limit(1)
@@ -186,5 +186,5 @@ export class GetPostDetailTuple extends GetPostTuple {
 
 export class RandomQuestionTuple {
   postId!: number;
-  question!: string;
+  title!: string;
 }

--- a/src/repository/post.query-repository.ts
+++ b/src/repository/post.query-repository.ts
@@ -145,6 +145,22 @@ export class PostQueryRepository {
 
     return plainToInstance(Post, post);
   }
+
+  async getRandomQuestion(): Promise<RandomQuestionTuple> {
+    const question = this.dataSource
+      .createQueryBuilder()
+      .from(Post, 'post')
+      .where("post.category ='오늘의 질문'")
+      .select([
+        'post.id as postId',
+        'post.title as question'
+      ])
+      .orderBy('RAND()')
+      .limit(1)
+      .getRawOne();
+
+    return plainToInstance(RandomQuestionTuple, question);
+  }
 }
 
 export class GetPostTuple {
@@ -166,4 +182,9 @@ export class GetPostDetailTuple extends GetPostTuple {
   memberDeletedAt!: Date;
   @Transform(({ value }) => value === '1')
   isMine: boolean;
+}
+
+export class RandomQuestionTuple {
+  postId!: number;
+  question!: string;
 }

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -27,6 +27,7 @@ import { PostEmojiQueryRepository } from 'src/repository/post-emoji.query-reposi
 import { PostHashTagQueryRepository } from 'src/repository/post-hash-tag.query-repository';
 import { PostCommentQueryRepository } from 'src/repository/post-comment.query-repository';
 import { PostDomainService } from 'src/domain-service/post.domain-service';
+import { TodayQuestionResponse } from 'src/dto/response/today-question.response';
 
 @Injectable()
 export class PostService {
@@ -278,6 +279,14 @@ export class PostService {
     const hashTagSearchTuples = await this.postHashTagQueryRepository.getHashTagSearchList(hashTagResult);
     const hashTagSearchInfo = hashTagSearchTuples.map((hashTagSearch) => GetHashTagSearch.from(hashTagSearch));
     return hashTagSearchInfo;
+  }
+
+  async getTodayQuestion(): Promise<TodayQuestionResponse> {
+    const randomQuestion = await this.postQueryRepository.getRandomQuestion();
+    if (!randomQuestion) {
+      return new TodayQuestionResponse(0, '');
+    }
+    return randomQuestion;
   }
 
   private async saveHashTags(postId: number, hashTags: HashTagDto[]): Promise<void> {


### PR DESCRIPTION
### 개요  

오늘의 질문 api를 추가하였습니다.

### 예상 리뷰시간  

3분

### 상세내용

아직 확정이 나지 않아, 일단 그럴듯하게 postId와 question을 리턴하게 만들었습니다.
오늘의 질문에 띄울 question은 제목과 내용 중 어떤 것으로 고민하다 제목으로 일단 해놓았습니다.
포스트 작성 시, 오늘의 질문 카테고리를 설정하면 무언가 내용 칸이 굉장히 간소해지는 것으로 바꾸는 작업이 필요할까 생각됩니다..! 이것으로 결정된다면 제목말고 내용으로 띄우겠습니다.



### 특이사항

쿼리딴에서 랜덤으로 한 개 가져오게 했는데, 레코드들이 많으면 응답 속도가 느려질 것 같습니다. 
일단은 적으니 이 방법을 쓰고, 점점 많아지면 서비스에서 랜덤으로 id 툭 튀어나오게 변경해야할 것 같네요.
지금 바꿔야할 수도 있고..