### PR TITLE
Feat: 관리자 페이지 인증 정보 불러오는 api 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -63,6 +63,8 @@ import { AuthorizationController } from './controller/authorization.controller';
 import { AuthorizationService } from './service/authorization.service';
 import { NotificationDomainService } from './domain-service/notification.domain-service';
 import { MemberDomainService } from './domain-service/member.domain-service';
+import { AdminController } from './controller/admin.controller';
+import { AuthorizationQueryRepository } from './repository/authorization.query-repository';
 
 @Module({
   imports: [
@@ -105,6 +107,7 @@ import { MemberDomainService } from './domain-service/member.domain-service';
     ProfileController,
     MemberController,
     AuthorizationController,
+    AdminController,
   ],
   providers: [
     // Service
@@ -140,6 +143,7 @@ import { MemberDomainService } from './domain-service/member.domain-service';
     PostHashTagQueryRepository,
     FeedEmojiQueryRepository,
     PostEmojiQueryRepository,
+    AuthorizationQueryRepository,
 
     // Strategy
     GithubStrategy,
@@ -152,4 +156,4 @@ import { MemberDomainService } from './domain-service/member.domain-service';
     Logger,
   ],
 })
-export class AppModule {}
+export class AppModule { }

--- a/src/controller/admin.controller.ts
+++ b/src/controller/admin.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { PaginationRequest } from 'src/common/pagination/pagination-request';
+import { PaginationResponse } from 'src/common/pagination/pagination-response';
+import { ApiPaginatedResponse } from 'src/common/pagination/pagination.decorator';
+import { AuthorizationResponse } from 'src/dto/response/authorization-response';
+import { RolesGuard } from 'src/guard/roles.guard';
+import { AuthorizationService } from 'src/service/authorization.service';
+
+@ApiTags('관리자 페이지')
+@Controller('admin')
+@UseGuards(RolesGuard)
+export class AdminController {
+  constructor(private readonly authorizationService: AuthorizationService) { }
+
+  @ApiOperation({ summary: '인증 목록 불러오기' })
+  @ApiPaginatedResponse(AuthorizationResponse)
+  @Get('authorization/list')
+  async getAuthorizationLists(
+    @Req() req,
+    @Query() paginationRequest: PaginationRequest
+  ): Promise<PaginationResponse<AuthorizationResponse>> {
+    const { authorizationInfo, totalCount } = await this.authorizationService.getAuthorizationList(req.user.id, paginationRequest);
+    return PaginationResponse.of({
+      data: AuthorizationResponse.from(authorizationInfo),
+      options: paginationRequest,
+      totalCount,
+    });
+  }
+}

--- a/src/domain-service/member.domain-service.ts
+++ b/src/domain-service/member.domain-service.ts
@@ -1,9 +1,9 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { MemberQueryRepository } from 'src/repository/member.query-repository';
 
 @Injectable()
 export class MemberDomainService {
-  constructor(private readonly memberQueryRepository: MemberQueryRepository) {}
+  constructor(private readonly memberQueryRepository: MemberQueryRepository) { }
 
   async getMemberIsNotDeletedById(memberId: number) {
     const member = await this.memberQueryRepository.getMemberIsNotDeletedById(memberId);
@@ -13,5 +13,12 @@ export class MemberDomainService {
     }
 
     return member;
+  }
+
+  async getMemberIsAdmin(memberId: number) {
+    const member = await this.memberQueryRepository.getMemberIsAdmin(memberId);
+    if (!member) {
+      throw new UnauthorizedException('권한이 없습니다.');
+    }
   }
 }

--- a/src/dto/get-authorization.dto.ts
+++ b/src/dto/get-authorization.dto.ts
@@ -1,0 +1,29 @@
+import { GetAuthorizationListTuple } from 'src/repository/authorization.query-repository';
+
+export class GetAuthorizationLists {
+  nickname!: string;
+  generation!: number;
+  imageUrl!: string;
+  createdAt!: Date;
+
+  constructor(
+    nickname: string,
+    generation: number,
+    imageUrl: string,
+    createdAt: Date
+  ) {
+    this.nickname = nickname;
+    this.generation = generation;
+    this.imageUrl = imageUrl;
+    this.createdAt = createdAt;
+  }
+
+  static from(tuple: GetAuthorizationListTuple) {
+    return new GetAuthorizationLists(
+      tuple.nickname,
+      tuple.generation,
+      tuple.imageUrl,
+      tuple.createdAt,
+    )
+  }
+}

--- a/src/dto/response/authorization-response.ts
+++ b/src/dto/response/authorization-response.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { GetAuthorizationLists } from '../get-authorization.dto';
+
+export class AuthorizationResponse {
+  @ApiProperty()
+  nickname!: string;
+  @ApiProperty()
+  generation!: number;
+  @ApiProperty()
+  imageUrl!: string;
+  @ApiProperty()
+  createdAt!: Date;
+
+  constructor(
+    nickname: string,
+    generation: number,
+    imageUrl: string,
+    createdAt: Date,
+  ) {
+    this.nickname = nickname;
+    this.generation = generation;
+    this.imageUrl = imageUrl;
+    this.createdAt = createdAt;
+  }
+
+  static from(dto: GetAuthorizationLists[]) {
+    return dto.map(
+      (getAuthorizationLists) =>
+        new AuthorizationResponse(
+          getAuthorizationLists.nickname,
+          getAuthorizationLists.generation,
+          getAuthorizationLists.imageUrl,
+          getAuthorizationLists.createdAt,
+        )
+    )
+  }
+}

--- a/src/entity/member.entity.ts
+++ b/src/entity/member.entity.ts
@@ -33,6 +33,9 @@ export class Member {
   @Column({ name: 'is_authorized', type: 'boolean', nullable: false })
   isAuthorized: boolean;
 
+  @Column({ name: 'is_admin', type: 'boolean', nullable: false })
+  isAdmin: boolean;
+
   @Column({ name: 'social_provider', type: 'enum', enum: SocialProvider, nullable: false })
   socialProvider!: SocialProvider;
 

--- a/src/repository/authorization.query-repository.ts
+++ b/src/repository/authorization.query-repository.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { PaginationRequest } from 'src/common/pagination/pagination-request';
+import { Authorization } from 'src/entity/authorization.entity';
+import { Member } from 'src/entity/member.entity';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class AuthorizationQueryRepository {
+  constructor(private readonly dataSource: DataSource) { }
+
+  async getAuthorizationList(paginationRequest: PaginationRequest)
+    : Promise<GetAuthorizationListTuple[]> {
+    const list = await this.getAuthorizationListBaseQuery()
+      .select([
+        'member.nickname as nickname',
+        'authorization.generation as generation',
+        'authorization.image_url as imageUrl',
+        'authorization.created_at as createdAt'
+      ])
+      .limit(paginationRequest.take)
+      .offset(paginationRequest.getSkip())
+      .orderBy('authorization.created_at', paginationRequest.order)
+      .getRawMany()
+    return plainToInstance(GetAuthorizationListTuple, list);
+  }
+
+  async getAuthorizationListCount(): Promise<number> {
+    return await this.getAuthorizationListBaseQuery().getCount();
+  }
+
+  private getAuthorizationListBaseQuery() {
+    let query = this.dataSource
+      .createQueryBuilder()
+      .from(Authorization, 'authorization')
+      .innerJoin(Member, 'member', 'member.id = authorization.member_id')
+      .where('member.deleted_at IS NULL');
+    return query;
+  }
+}
+
+export class GetAuthorizationListTuple {
+  nickname: string;
+  generation: number;
+  imageUrl: string;
+  createdAt: Date;
+}

--- a/src/repository/member.query-repository.ts
+++ b/src/repository/member.query-repository.ts
@@ -6,7 +6,7 @@ import { DataSource } from 'typeorm';
 
 @Injectable()
 export class MemberQueryRepository {
-  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) { }
 
   async getMember(externalId: string): Promise<Member | undefined> {
     const member = await this.dataSource
@@ -47,6 +47,18 @@ export class MemberQueryRepository {
 
     return plainToInstance(GetNotificationSettingTuple, notificationSetting);
   }
+
+  async getMemberIsAdmin(memberId: number): Promise<Member | undefined> {
+    const member = await this.dataSource
+      .createQueryBuilder()
+      .from(Member, 'member')
+      .where('member.id = :memberId', { memberId })
+      .andWhere('member.isAdmin = TRUE')
+      .select('member')
+      .getOne();
+    return plainToInstance(Member, member);
+  }
+
 }
 
 class GetNotificationSettingTuple {

--- a/src/service/authorization.service.ts
+++ b/src/service/authorization.service.ts
@@ -1,9 +1,11 @@
-import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Injectable, UnauthorizedException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
+import { PaginationRequest } from 'src/common/pagination/pagination-request';
 import { MemberDomainService } from 'src/domain-service/member.domain-service';
+import { GetAuthorizationLists } from 'src/dto/get-authorization.dto';
 import { AuthorizationRequest } from "src/dto/request/authorization.request";
 import { Authorization } from "src/entity/authorization.entity";
-import { Member } from "src/entity/member.entity";
+import { AuthorizationQueryRepository } from 'src/repository/authorization.query-repository';
 import { Repository } from "typeorm";
 
 @Injectable()
@@ -11,6 +13,7 @@ export class AuthorizationService {
   constructor(
     @InjectRepository(Authorization) private readonly authorizationRepository: Repository<Authorization>,
     private readonly memberDomainService: MemberDomainService,
+    private readonly authorizationQueryRepository: AuthorizationQueryRepository,
   ) { }
 
   async postAuthorizationInfo(memberId: number, request: AuthorizationRequest): Promise<void> {
@@ -29,5 +32,19 @@ export class AuthorizationService {
       generation: request.generation,
       imageUrl: request.imageUrl
     });
+  }
+
+  async getAuthorizationList(memberId: number, request: PaginationRequest) {
+    if (!(memberId === 1 || (memberId >= 3 && memberId <= 8) || memberId === 21)) {
+      throw new UnauthorizedException('권한이 없습니다.');
+    }
+    const authorizationLists = await this.authorizationQueryRepository.getAuthorizationList(request);
+    const totalCount = await this.authorizationQueryRepository.getAuthorizationListCount();
+
+    const authorizationInfo = authorizationLists.map((list) => {
+      return GetAuthorizationLists.from(list);
+    })
+
+    return { authorizationInfo, totalCount };
   }
 }

--- a/src/service/authorization.service.ts
+++ b/src/service/authorization.service.ts
@@ -35,9 +35,7 @@ export class AuthorizationService {
   }
 
   async getAuthorizationList(memberId: number, request: PaginationRequest) {
-    if (!(memberId === 1 || (memberId >= 3 && memberId <= 8) || memberId === 21)) {
-      throw new UnauthorizedException('권한이 없습니다.');
-    }
+    await this.memberDomainService.getMemberIsAdmin(memberId);
     const authorizationLists = await this.authorizationQueryRepository.getAuthorizationList(request);
     const totalCount = await this.authorizationQueryRepository.getAuthorizationListCount();
 


### PR DESCRIPTION
### 개요  

관리자 페이지 인증 정보 목록 불러오는 api를 추가했습니다!

### 예상 리뷰시간  

5분

### 상세내용

일단 닉네임, 기수, 이미지 url, 인증보낸 시간을 넣어주었습니다.
피드, 포스트, 팔로우/팔로잉 목록과 같이 페이지네이션 객체를 내려주었습니다.

### 특이사항
