### PR TITLE
Feat: 관리자 페이지 승인 및 거절 api 추가

### DIFF
--- a/src/controller/admin.controller.ts
+++ b/src/controller/admin.controller.ts
@@ -34,4 +34,11 @@ export class AdminController {
   async postAuthorizationAcception(@Req() req, @Param('memberId') memberId: number): Promise<void> {
     await this.authorizationService.acceptAuthorization(req.user.id, memberId);
   }
+
+  @ApiOperation({ summary: '인증 거절' })
+  @ApiParam({ name: 'memberId', required: true, description: '멤버 id' })
+  @Post(':memberId/decline')
+  async postAuthorizationDecline(@Req() req, @Param('memberId') memberId: number): Promise<void> {
+    await this.authorizationService.declineAuthorization(req.user.id, memberId);
+  }
 }

--- a/src/controller/admin.controller.ts
+++ b/src/controller/admin.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Param, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import { PaginationRequest } from 'src/common/pagination/pagination-request';
 import { PaginationResponse } from 'src/common/pagination/pagination-response';
 import { ApiPaginatedResponse } from 'src/common/pagination/pagination.decorator';
@@ -26,5 +26,12 @@ export class AdminController {
       options: paginationRequest,
       totalCount,
     });
+  }
+
+  @ApiOperation({ summary: '인증 승인' })
+  @ApiParam({ name: 'memberId', required: true, description: '멤버 id' })
+  @Post(':memberId/accept')
+  async postAuthorizationAcception(@Req() req, @Param('memberId') memberId: number): Promise<void> {
+    await this.authorizationService.acceptAuthorization(req.user.id, memberId);
   }
 }

--- a/src/dto/get-authorization.dto.ts
+++ b/src/dto/get-authorization.dto.ts
@@ -1,17 +1,20 @@
 import { GetAuthorizationListTuple } from 'src/repository/authorization.query-repository';
 
 export class GetAuthorizationLists {
+  memberId!: number;
   nickname!: string;
   generation!: number;
   imageUrl!: string;
   createdAt!: Date;
 
   constructor(
+    memberId: number,
     nickname: string,
     generation: number,
     imageUrl: string,
     createdAt: Date
   ) {
+    this.memberId = memberId;
     this.nickname = nickname;
     this.generation = generation;
     this.imageUrl = imageUrl;
@@ -20,6 +23,7 @@ export class GetAuthorizationLists {
 
   static from(tuple: GetAuthorizationListTuple) {
     return new GetAuthorizationLists(
+      tuple.memberId,
       tuple.nickname,
       tuple.generation,
       tuple.imageUrl,

--- a/src/dto/response/authorization-response.ts
+++ b/src/dto/response/authorization-response.ts
@@ -3,6 +3,8 @@ import { GetAuthorizationLists } from '../get-authorization.dto';
 
 export class AuthorizationResponse {
   @ApiProperty()
+  memberId!: number;
+  @ApiProperty()
   nickname!: string;
   @ApiProperty()
   generation!: number;
@@ -12,11 +14,13 @@ export class AuthorizationResponse {
   createdAt!: Date;
 
   constructor(
+    memberId: number,
     nickname: string,
     generation: number,
     imageUrl: string,
     createdAt: Date,
   ) {
+    this.memberId = memberId;
     this.nickname = nickname;
     this.generation = generation;
     this.imageUrl = imageUrl;
@@ -27,6 +31,7 @@ export class AuthorizationResponse {
     return dto.map(
       (getAuthorizationLists) =>
         new AuthorizationResponse(
+          getAuthorizationLists.memberId,
           getAuthorizationLists.nickname,
           getAuthorizationLists.generation,
           getAuthorizationLists.imageUrl,

--- a/src/entity/member.entity.ts
+++ b/src/entity/member.entity.ts
@@ -89,4 +89,8 @@ export class Member {
         break;
     }
   }
+
+  setIsAuthorized() {
+    this.isAuthorized = true;
+  }
 }

--- a/src/repository/authorization.query-repository.ts
+++ b/src/repository/authorization.query-repository.ts
@@ -13,6 +13,7 @@ export class AuthorizationQueryRepository {
     : Promise<GetAuthorizationListTuple[]> {
     const list = await this.getAuthorizationListBaseQuery()
       .select([
+        'member.id as memberId',
         'member.nickname as nickname',
         'authorization.generation as generation',
         'authorization.image_url as imageUrl',
@@ -40,6 +41,7 @@ export class AuthorizationQueryRepository {
 }
 
 export class GetAuthorizationListTuple {
+  memberId: number;
   nickname: string;
   generation: number;
   imageUrl: string;

--- a/src/service/authorization.service.ts
+++ b/src/service/authorization.service.ts
@@ -64,4 +64,19 @@ export class AuthorizationService {
     await this.authorizationRepository.remove(authorizedMemberInfo);
 
   }
+
+  async declineAuthorization(adminId: number, memberId: number) {
+    await this.memberDomainService.getMemberIsAdmin(adminId);
+
+    const memberInfo = await this.memberDomainService.getMemberIsNotDeletedById(memberId);
+    if (memberInfo.isAuthorized) {
+      throw new NotFoundException('이미 인증된 사용자입니다.');
+    }
+    const authorizedMemberInfo = await this.authorizationRepository.findOneBy({ memberId });
+    if (!authorizedMemberInfo) {
+      throw new NotFoundException('해당 인증을 찾을 수 없습니다.');
+    }
+    await this.authorizationRepository.remove(authorizedMemberInfo);
+
+  }
 }


### PR DESCRIPTION
### 개요  

관리자 페이지에서 유저가 보낸 인증을 승인 및 거절하는 api를 추가하였습니다.

### 예상 리뷰시간  

3분

### 상세내용

authorization 테이블에 있는 데이터를 지우고, 승인하면 isAuthorized가 true로 바뀌고, 거절하면 그대로 놔둡니다.

### 특이사항
