### PR TITLE
Feat: 피드 정렬 api 추가

### DIFF
--- a/src/controller/feed.controller.ts
+++ b/src/controller/feed.controller.ts
@@ -30,6 +30,7 @@ import { ApiPaginatedResponse } from 'src/common/pagination/pagination.decorator
 import { Roles } from 'src/common/roles/roles.decorator';
 import { PostFeedCommentRequestDto } from 'src/dto/request/post-feed-comment.request';
 import { PostFeedRequestDto } from 'src/dto/request/post-feed.request.dto';
+import { SortFeedList } from 'src/dto/request/sort-feed-list.request';
 import { GetFeedCommentResponseDto } from 'src/dto/response/get-feed-comment.response.dto';
 import { GetFeedDetailResponseDto } from 'src/dto/response/get-feed-detail.response.dto';
 import { GetFeedResponseDto } from 'src/dto/response/get-feed.response.dto';
@@ -90,14 +91,15 @@ export class FeedController {
   @Get('/list')
   async getFeedList(
     @Req() req,
-    @Query() paginationRequest: PaginationRequest
+    @Query() sortFeedList: SortFeedList
   ): Promise<PaginationResponse<GetFeedResponseDto>> {
     const userId = req.user?.id;
-    const { feedList, totalCount } = await this.feedService.getFeedList(paginationRequest, userId);
+    const userGeneration = req.user?.generation;
+    const { feedList, totalCount } = await this.feedService.getFeedList(sortFeedList, userId, userGeneration);
 
     return PaginationResponse.of({
       data: feedList,
-      options: paginationRequest,
+      options: sortFeedList,
       totalCount,
     });
   }

--- a/src/dto/request/sort-feed-list.request.ts
+++ b/src/dto/request/sort-feed-list.request.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsOptional } from 'class-validator';
+import { PaginationRequest } from 'src/common/pagination/pagination-request';
+import { CategoryType, ListSortBy } from 'src/entity/common/Enums';
+
+export class SortFeedList extends PaginationRequest {
+  @ApiPropertyOptional({ description: '정렬 기준', enum: ListSortBy })
+  @Type(() => String)
+  @IsOptional()
+  sortBy!: ListSortBy;
+}


### PR DESCRIPTION
### 개요  

피드 정렬 api를 추가했읍니다.

### 예상 리뷰시간  

3분

### 상세내용

sortBy와 category를 가지고 있는 포스트와는 다르게,
피드는 sortBy밖에 없읍니다.

[ALL, BY_FOLLOW, BY_GENERATION] 쿼리파라미터로 불러주시면 됩닏아.

### 특이사항
