### PR TITLE
Feat: 대댓글 쓰기 api

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -69,6 +69,10 @@ import { GoogleStrategy } from './strategy/google-strategy';
 import { GoogleAuthGuard } from './guard/google-auth.guard';
 import { AdminGuard } from './guard/admin.guard';
 import { PostScrap } from './entity/post_scrap.entity';
+import { PostReply } from './entity/post_reply.entity';
+import { PostReplyHeart } from './entity/post_reply_heart.entity';
+import { FeedReply } from './entity/feed_reply.entity';
+import { FeedReplyHeart } from './entity/feed_reply_heart.entity';
 
 @Module({
   imports: [
@@ -85,9 +89,13 @@ import { PostScrap } from './entity/post_scrap.entity';
       FeedEmoji,
       FeedComment,
       FeedCommentHeart,
+      FeedReply,
+      FeedReplyHeart,
       Post,
       PostComment,
       PostCommentHeart,
+      PostReply,
+      PostReplyHeart,
       PostScrap,
       PostHashTag,
       HashTag,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -74,6 +74,7 @@ import { PostReplyHeart } from './entity/post_reply_heart.entity';
 import { FeedReply } from './entity/feed_reply.entity';
 import { FeedReplyHeart } from './entity/feed_reply_heart.entity';
 import { PostReplyService } from './service/post-reply.service';
+import { FeedReplyService } from './service/feed-reply.service';
 
 @Module({
   imports: [
@@ -130,6 +131,7 @@ import { PostReplyService } from './service/post-reply.service';
     OauthAuthenticationService,
     FeedService,
     FeedCommentService,
+    FeedReplyService,
     PostService,
     PostReplyService,
     ImageService,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -73,6 +73,7 @@ import { PostReply } from './entity/post_reply.entity';
 import { PostReplyHeart } from './entity/post_reply_heart.entity';
 import { FeedReply } from './entity/feed_reply.entity';
 import { FeedReplyHeart } from './entity/feed_reply_heart.entity';
+import { PostReplyService } from './service/post-reply.service';
 
 @Module({
   imports: [
@@ -130,6 +131,7 @@ import { FeedReplyHeart } from './entity/feed_reply_heart.entity';
     FeedService,
     FeedCommentService,
     PostService,
+    PostReplyService,
     ImageService,
     FollowService,
     NotificationService,

--- a/src/controller/feed.controller.ts
+++ b/src/controller/feed.controller.ts
@@ -274,7 +274,7 @@ export class FeedController {
   }
 
   @ApiOperation({ summary: '피드 대댓글 쓰기' })
-  @ApiParam({ name: 'postId', required: true, description: '피드 id' })
+  @ApiParam({ name: 'feedId', required: true, description: '피드 id' })
   @ApiParam({ name: 'commentId', required: true, description: '댓글 id' })
   @ApiBody({ description: '대댓글 내용', schema: { type: 'object', properties: { content: { type: 'string' } } } })
   @Post(':feedId/comment/:commentId/write')

--- a/src/controller/feed.controller.ts
+++ b/src/controller/feed.controller.ts
@@ -37,6 +37,7 @@ import { GetFeedResponseDto } from 'src/dto/response/get-feed.response.dto';
 import { ImageResponse } from 'src/dto/response/image.response';
 import { RolesGuard } from 'src/guard/roles.guard';
 import { FeedCommentService } from 'src/service/feed-comment.service';
+import { FeedReplyService } from 'src/service/feed-reply.service';
 import { FeedService } from 'src/service/feed.service';
 import { ImageService } from 'src/service/image.service';
 
@@ -47,6 +48,7 @@ export class FeedController {
   constructor(
     private readonly feedService: FeedService,
     private readonly feedCommentService: FeedCommentService,
+    private readonly feedReplyService: FeedReplyService,
     private readonly imageService: ImageService,
     private readonly configService: ConfigService,
   ) { }
@@ -269,5 +271,19 @@ export class FeedController {
     const bucket = this.configService.get('AWS_S3_UPLOAD_BUCKET_FEED');
 
     await this.imageService.deleteImage(imageUrls, bucket);
+  }
+
+  @ApiOperation({ summary: '피드 대댓글 쓰기' })
+  @ApiParam({ name: 'postId', required: true, description: '피드 id' })
+  @ApiParam({ name: 'commentId', required: true, description: '댓글 id' })
+  @ApiBody({ description: '대댓글 내용', schema: { type: 'object', properties: { content: { type: 'string' } } } })
+  @Post(':feedId/comment/:commentId/write')
+  async writeFeedReply(
+    @Param('feedId', ParseIntPipe) feedId: number,
+    @Param('commentId', ParseIntPipe) commentId: number,
+    @Req() req,
+    @Body('content') content: string,
+  ): Promise<void> {
+    return this.feedReplyService.writeFeedReply(feedId, commentId, req.user.id, content);
   }
 }

--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -40,6 +40,7 @@ import { PostListResponse } from 'src/dto/response/post-list.response';
 import { TodayQuestionResponse } from 'src/dto/response/today-question.response';
 import { RolesGuard } from 'src/guard/roles.guard';
 import { ImageService } from 'src/service/image.service';
+import { PostReplyService } from 'src/service/post-reply.service';
 import { PostService } from 'src/service/post.service';
 
 @ApiTags('포스트')
@@ -48,6 +49,7 @@ import { PostService } from 'src/service/post.service';
 export class PostController {
   constructor(
     private readonly postService: PostService,
+    private readonly postReplyService: PostReplyService,
     private readonly imageService: ImageService,
     private readonly configService: ConfigService,
   ) { }
@@ -309,5 +311,19 @@ export class PostController {
   @Delete(':postId/scrap')
   async deleteArticleScrap(@Req() req, @Param('postId', ParseIntPipe) postId: number): Promise<void> {
     return await this.postService.deleteScrap(req.user.id, postId);
+  }
+
+  @ApiOperation({ summary: '포스트 대댓글 쓰기' })
+  @ApiParam({ name: 'postId', required: true, description: '포스트 id' })
+  @ApiParam({ name: 'commentId', required: true, description: '댓글 id' })
+  @ApiBody({ description: '대댓글 내용', schema: { type: 'object', properties: { content: { type: 'string' } } } })
+  @Post(':postId/comment/:commentId/write')
+  async writePostReply(
+    @Param('postId', ParseIntPipe) postId: number,
+    @Param('commentId', ParseIntPipe) commentId: number,
+    @Req() req,
+    @Body('content') content: string,
+  ): Promise<void> {
+    return this.postReplyService.writePostReply(postId, commentId, req.user.id, content);
   }
 }

--- a/src/entity/feed_reply.entity.ts
+++ b/src/entity/feed_reply.entity.ts
@@ -1,0 +1,22 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity({ name: 'feed_reply' })
+export class FeedReply {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ name: 'comment_id', nullable: false })
+  commentId!: number;
+
+  @Column({ name: 'member_id', nullable: false })
+  memberID!: number;
+
+  @Column({ name: 'content', nullable: false, length: 300 })
+  content!: string;
+
+  @CreateDateColumn({ name: 'created_at', nullable: false })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', nullable: false })
+  updatedAt!: Date;
+}

--- a/src/entity/feed_reply.entity.ts
+++ b/src/entity/feed_reply.entity.ts
@@ -5,11 +5,14 @@ export class FeedReply {
   @PrimaryGeneratedColumn()
   id!: number;
 
+  @Column({ name: 'feed_id', nullable: false })
+  feedId!: number;
+
   @Column({ name: 'comment_id', nullable: false })
   commentId!: number;
 
   @Column({ name: 'member_id', nullable: false })
-  memberID!: number;
+  memberId!: number;
 
   @Column({ name: 'content', nullable: false, length: 300 })
   content!: string;

--- a/src/entity/feed_reply_heart.entity.ts
+++ b/src/entity/feed_reply_heart.entity.ts
@@ -5,6 +5,9 @@ export class FeedReplyHeart {
   @PrimaryGeneratedColumn()
   id!: number;
 
+  @Column({ name: 'feed_id', nullable: false })
+  feedId!: number;
+
   @Column({ name: 'reply_id', nullable: false })
   replyId!: number;
 

--- a/src/entity/feed_reply_heart.entity.ts
+++ b/src/entity/feed_reply_heart.entity.ts
@@ -1,0 +1,19 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity({ name: 'feed_reply_heart' })
+export class FeedReplyHeart {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ name: 'reply_id', nullable: false })
+  replyId!: number;
+
+  @Column({ name: 'member_id', nullable: false })
+  memberId!: number;
+
+  @CreateDateColumn({ name: 'created_at', nullable: false })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', nullable: false })
+  updatedAt!: Date;
+}

--- a/src/entity/post_reply.entity.ts
+++ b/src/entity/post_reply.entity.ts
@@ -1,0 +1,22 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity({ name: 'post_reply' })
+export class PostReply {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ name: 'comment_id', nullable: false })
+  commentId!: number;
+
+  @Column({ name: 'member_id', nullable: false })
+  memberID!: number;
+
+  @Column({ name: 'content', nullable: false, length: 300 })
+  content!: string;
+
+  @CreateDateColumn({ name: 'created_at', nullable: false })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', nullable: false })
+  updatedAt!: Date;
+}

--- a/src/entity/post_reply.entity.ts
+++ b/src/entity/post_reply.entity.ts
@@ -5,11 +5,14 @@ export class PostReply {
   @PrimaryGeneratedColumn()
   id!: number;
 
+  @Column({ name: 'post_id', nullable: false })
+  postId!: number;
+
   @Column({ name: 'comment_id', nullable: false })
   commentId!: number;
 
   @Column({ name: 'member_id', nullable: false })
-  memberID!: number;
+  memberId!: number;
 
   @Column({ name: 'content', nullable: false, length: 300 })
   content!: string;

--- a/src/entity/post_reply_heart.entity.ts
+++ b/src/entity/post_reply_heart.entity.ts
@@ -1,0 +1,19 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity({ name: 'Post_reply_heart' })
+export class PostReplyHeart {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ name: 'reply_id', nullable: false })
+  replyId!: number;
+
+  @Column({ name: 'member_id', nullable: false })
+  memberId!: number;
+
+  @CreateDateColumn({ name: 'created_at', nullable: false })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', nullable: false })
+  updatedAt!: Date;
+}

--- a/src/entity/post_reply_heart.entity.ts
+++ b/src/entity/post_reply_heart.entity.ts
@@ -5,6 +5,9 @@ export class PostReplyHeart {
   @PrimaryGeneratedColumn()
   id!: number;
 
+  @Column({ name: 'post_id', nullable: false })
+  postId!: number;
+
   @Column({ name: 'reply_id', nullable: false })
   replyId!: number;
 

--- a/src/service/feed-reply.service.ts
+++ b/src/service/feed-reply.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FeedDomainService } from 'src/domain-service/feed.domain-service';
+import { FeedComment } from 'src/entity/feed_comment.entity';
+import { FeedReply } from 'src/entity/feed_reply.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class FeedReplyService {
+  constructor(
+    private readonly feedDomainService: FeedDomainService,
+    @InjectRepository(FeedComment) private readonly feedCommentRepository: Repository<FeedComment>,
+    @InjectRepository(FeedReply) private readonly feedReplyRepository: Repository<FeedReply>,
+  ) { }
+
+  async writeFeedReply(feedId: number, commentId: number, memberId: number, content: string): Promise<void> {
+    await this.feedDomainService.getFeedIsNotDeleted(feedId);
+
+    const commentInfo = await this.feedCommentRepository.findOneBy({ feedId, id: commentId });
+    if (!commentInfo) {
+      throw new NotFoundException('답글을 생성할 댓글을 찾을 수 없습니다.');
+    }
+    const reply = await this.feedReplyRepository.save({
+      feedId,
+      commentId,
+      memberId,
+      content,
+    });
+
+  }
+}

--- a/src/service/post-reply.service.ts
+++ b/src/service/post-reply.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { PostDomainService } from 'src/domain-service/post.domain-service';
+import { PostComment } from 'src/entity/post_comment.entity';
+import { PostReply } from 'src/entity/post_reply.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class PostReplyService {
+  constructor(
+    private readonly postDomainService: PostDomainService,
+    @InjectRepository(PostComment) private readonly postCommentRepository: Repository<PostComment>,
+    @InjectRepository(PostReply) private readonly postReplyRepository: Repository<PostReply>,
+  ) { }
+
+  async writePostReply(postId: number, commentId: number, memberId: number, content: string): Promise<void> {
+    await this.postDomainService.getPostIsNotDeleted(postId);
+
+    const commentInfo = await this.postCommentRepository.findOneBy({ postId, id: commentId });
+    if (!commentInfo) {
+      throw new NotFoundException('답글을 생성할 댓글을 찾을 수 없습니다.');
+    }
+
+    const reply = await this.postReplyRepository.save({
+      postId,
+      commentId,
+      memberId,
+      content,
+    });
+
+  }
+}


### PR DESCRIPTION
### 개요  

피드 / 포스트 대댓글 쓰기 api 추가하였습니다.

### 예상 리뷰시간  

5분

### 상세내용

쓰기 api는 어렵지 않으니 일단 추가하였습니다.
나머지 수정 / 삭제 / 대댓글 좋아요 / 대댓글 좋아요 취소 / [피드|포스트] 상세 불러올 때 대댓글 응답 추가 api도 만들 예정입니다.

### 특이사항
