### PR TITLE
Feat: 대댓글 조회 API 추가

### DIFF
--- a/src/controller/feed.controller.ts
+++ b/src/controller/feed.controller.ts
@@ -316,7 +316,7 @@ export class FeedController {
 
   @ApiOperation({ summary: '피드 대댓글 조회' })
   @ApiParam({ name: 'commentId', required: true, description: '피드 댓글 id' })
-  @Get('comment/:commentId/reply')
+  @Get('comment/:commentId/reply/list')
   async viewFeedReply(
     @Param('commentId', ParseIntPipe) commentId: number,
     @Req() req,

--- a/src/controller/feed.controller.ts
+++ b/src/controller/feed.controller.ts
@@ -31,6 +31,7 @@ import { Roles } from 'src/common/roles/roles.decorator';
 import { PostFeedCommentRequestDto } from 'src/dto/request/post-feed-comment.request';
 import { PostFeedRequestDto } from 'src/dto/request/post-feed.request.dto';
 import { SortFeedList } from 'src/dto/request/sort-feed-list.request';
+import { FeedReplyListResponse } from 'src/dto/response/feed-reply-list.response';
 import { GetFeedCommentResponseDto } from 'src/dto/response/get-feed-comment.response.dto';
 import { GetFeedDetailResponseDto } from 'src/dto/response/get-feed-detail.response.dto';
 import { GetFeedResponseDto } from 'src/dto/response/get-feed.response.dto';
@@ -311,5 +312,26 @@ export class FeedController {
     @Req() req,
   ): Promise<void> {
     return this.feedReplyService.deleteFeedReply(feedId, replyId, req.user.id);
+  }
+
+  @ApiOperation({ summary: '피드 대댓글 조회' })
+  @ApiParam({ name: 'commentId', required: true, description: '피드 댓글 id' })
+  @Get('comment/:commentId/reply')
+  async viewFeedReply(
+    @Param('commentId', ParseIntPipe) commentId: number,
+    @Req() req,
+    @Query() PaginationRequest: PaginationRequest,
+  ): Promise<PaginationResponse<FeedReplyListResponse>> {
+    const { feedReplyInfo, totalCount } = await this.feedReplyService.getFeedReplyList(
+      commentId,
+      req.user.id,
+      PaginationRequest,
+    )
+    const feedReplyData = feedReplyInfo.map((info) => FeedReplyListResponse.from(info));
+    return PaginationResponse.of({
+      data: feedReplyData,
+      options: PaginationRequest,
+      totalCount,
+    });
   }
 }

--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -356,7 +356,7 @@ export class PostController {
 
   @ApiOperation({ summary: '포스트 대댓글 조회' })
   @ApiParam({ name: 'commentId', required: true, description: '포스트 댓글 id' })
-  @Get('comment/:commentId/reply')
+  @Get('comment/:commentId/reply/list')
   async viewPostReply(
     @Param('commentId', ParseIntPipe) commentId: number,
     @Req() req,

--- a/src/controller/post.controller.ts
+++ b/src/controller/post.controller.ts
@@ -37,6 +37,7 @@ import { ImageResponse } from 'src/dto/response/image.response';
 import { PostCommentListResponse } from 'src/dto/response/post-comment-list.response';
 import { PostDetailResponse } from 'src/dto/response/post-detail.response';
 import { PostListResponse } from 'src/dto/response/post-list.response';
+import { PostReplyListResponse } from 'src/dto/response/post-reply-list.response';
 import { TodayQuestionResponse } from 'src/dto/response/today-question.response';
 import { RolesGuard } from 'src/guard/roles.guard';
 import { ImageService } from 'src/service/image.service';
@@ -351,5 +352,26 @@ export class PostController {
     @Req() req,
   ): Promise<void> {
     return this.postReplyService.deletePostReply(postId, replyId, req.user.id);
+  }
+
+  @ApiOperation({ summary: '포스트 대댓글 조회' })
+  @ApiParam({ name: 'commentId', required: true, description: '포스트 댓글 id' })
+  @Get('comment/:commentId/reply')
+  async viewPostReply(
+    @Param('commentId', ParseIntPipe) commentId: number,
+    @Req() req,
+    @Query() PaginationRequest: PaginationRequest,
+  ): Promise<PaginationResponse<PostReplyListResponse>> {
+    const { postReplyInfo, totalCount } = await this.postReplyService.getPostReplyList(
+      commentId,
+      req.user.id,
+      PaginationRequest,
+    )
+    const postReplyData = postReplyInfo.map((info) => PostReplyListResponse.from(info));
+    return PaginationResponse.of({
+      data: postReplyData,
+      options: PaginationRequest,
+      totalCount,
+    });
   }
 }

--- a/src/dto/get-feed-reply-list.dto.ts
+++ b/src/dto/get-feed-reply-list.dto.ts
@@ -1,0 +1,50 @@
+import { GetFeedReplyTuple } from 'src/repository/feed-comment.query-repository';
+import { FeedReplyDto, FeedReplyWriterDto } from 'src/service/feed-reply.service';
+
+export class GetFeedReplyList {
+  writer: FeedReplyWriterDto;
+  reply: FeedReplyDto;
+
+  constructor(
+    memberId: number,
+    nickname: string,
+    generation: number,
+    profileImageUrl: string,
+    replyId: number,
+    content: string,
+    heartCount: number,
+    createdAt: Date,
+    isHearted: boolean,
+    isMine: boolean,
+  ) {
+    this.writer = {
+      id: memberId,
+      nickname,
+      generation,
+      profileImageUrl,
+    };
+    this.reply = {
+      id: replyId,
+      content,
+      heartCount,
+      createdAt,
+      isHearted,
+      isMine,
+    };
+  }
+
+  static from(tuple: GetFeedReplyTuple) {
+    return new GetFeedReplyList(
+      tuple.memberId,
+      tuple.nickname,
+      tuple.generation,
+      tuple.profileImageUrl,
+      tuple.replyId,
+      tuple.content,
+      tuple.heartCount,
+      tuple.createdAt,
+      tuple.isHearted,
+      tuple.isMine,
+    );
+  }
+}

--- a/src/dto/get-post-comment-list.dto.ts
+++ b/src/dto/get-post-comment-list.dto.ts
@@ -16,6 +16,7 @@ export class GetPostCommentList {
     createdAt: Date,
     isHearted: boolean,
     isMine: boolean,
+    isReplied: boolean,
   ) {
     this.writer = {
       id: memberId,
@@ -30,6 +31,7 @@ export class GetPostCommentList {
       createdAt,
       isHearted,
       isMine,
+      isReplied,
     };
   }
 
@@ -45,6 +47,7 @@ export class GetPostCommentList {
       tuple.createdAt,
       tuple.isHearted,
       tuple.isMine,
+      tuple.isReplied,
     );
   }
 }

--- a/src/dto/get-post-reply-list.dto.ts
+++ b/src/dto/get-post-reply-list.dto.ts
@@ -1,0 +1,50 @@
+import { GetPostReplyTuple } from 'src/repository/post-comment.query-repository';
+import { PostReplyDto, PostReplyWriterDto } from 'src/service/post-reply.service';
+
+export class GetPostReplyList {
+  writer: PostReplyWriterDto;
+  reply: PostReplyDto;
+
+  constructor(
+    memberId: number,
+    nickname: string,
+    generation: number,
+    profileImageUrl: string,
+    replyId: number,
+    content: string,
+    heartCount: number,
+    createdAt: Date,
+    isHearted: boolean,
+    isMine: boolean,
+  ) {
+    this.writer = {
+      id: memberId,
+      nickname,
+      generation,
+      profileImageUrl,
+    };
+    this.reply = {
+      id: replyId,
+      content,
+      heartCount,
+      createdAt,
+      isHearted,
+      isMine,
+    };
+  }
+
+  static from(tuple: GetPostReplyTuple) {
+    return new GetPostReplyList(
+      tuple.memberId,
+      tuple.nickname,
+      tuple.generation,
+      tuple.profileImageUrl,
+      tuple.replyId,
+      tuple.content,
+      tuple.heartCount,
+      tuple.createdAt,
+      tuple.isHearted,
+      tuple.isMine,
+    );
+  }
+}

--- a/src/dto/response/feed-reply-list.response.ts
+++ b/src/dto/response/feed-reply-list.response.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { FeedReplyDto, FeedReplyWriterDto } from 'src/service/feed-reply.service';
+
+
+export class FeedReplyListResponse {
+  @ApiProperty({
+    type: {
+      id: { type: 'number' },
+      nickname: { type: 'string' },
+      generation: { type: 'number' },
+      profileImageUrl: { type: 'string' },
+    },
+  })
+  writer: FeedReplyWriterDto;
+  @ApiProperty({
+    type: {
+      id: { type: 'number' },
+      content: { type: 'string' },
+      heartCount: { type: 'number' },
+      isHearted: { type: 'boolean' },
+      createdAt: { type: 'string' },
+      isMine: { type: 'boolean' },
+    },
+  })
+  reply: FeedReplyDto;
+
+  constructor(writer: FeedReplyWriterDto, reply: FeedReplyDto) {
+    this.writer = writer;
+    this.reply = reply;
+  }
+
+  static from({ writer, reply }: { writer: FeedReplyWriterDto; reply: FeedReplyDto; }) {
+    return new FeedReplyListResponse(writer, reply);
+  }
+}

--- a/src/dto/response/get-feed-comment.response.dto.ts
+++ b/src/dto/response/get-feed-comment.response.dto.ts
@@ -20,6 +20,7 @@ export class GetFeedCommentResponseDto {
       isHearted: { type: 'boolean' },
       createdAt: { type: 'string' },
       isMine: { type: 'boolean' },
+      isReplied: { type: 'boolean' },
     },
   })
   comment: FeedCommentDto;

--- a/src/dto/response/post-comment-list.response.ts
+++ b/src/dto/response/post-comment-list.response.ts
@@ -19,6 +19,7 @@ export class PostCommentListResponse {
       isHearted: { type: 'boolean' },
       createdAt: { type: 'string' },
       isMine: { type: 'boolean' },
+      isReplied: { type: 'boolean' },
     },
   })
   comment: PostCommentDto;

--- a/src/dto/response/post-reply-list.response.ts
+++ b/src/dto/response/post-reply-list.response.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PostReplyDto, PostReplyWriterDto } from 'src/service/post-reply.service';
+
+export class PostReplyListResponse {
+  @ApiProperty({
+    type: {
+      id: { type: 'number' },
+      nickname: { type: 'string' },
+      generation: { type: 'number' },
+      profileImageUrl: { type: 'string' },
+    },
+  })
+  writer: PostReplyWriterDto;
+  @ApiProperty({
+    type: {
+      id: { type: 'number' },
+      content: { type: 'string' },
+      heartCount: { type: 'number' },
+      isHearted: { type: 'boolean' },
+      createdAt: { type: 'string' },
+      isMine: { type: 'boolean' },
+    },
+  })
+  reply: PostReplyDto;
+
+  constructor(writer: PostReplyWriterDto, reply: PostReplyDto) {
+    this.writer = writer;
+    this.reply = reply;
+  }
+
+  static from({ writer, reply }: { writer: PostReplyWriterDto; reply: PostReplyDto; }) {
+    return new PostReplyListResponse(writer, reply);
+  }
+}

--- a/src/entity/feed_reply.entity.ts
+++ b/src/entity/feed_reply.entity.ts
@@ -17,6 +17,9 @@ export class FeedReply {
   @Column({ name: 'content', nullable: false, length: 300 })
   content!: string;
 
+  @Column({ name: 'heart_count', nullable: false })
+  heartCount!: number;
+
   @Column({ name: 'deleted_at', type: 'timestamp', nullable: true })
   deletedAt?: Date;
 

--- a/src/entity/post_reply.entity.ts
+++ b/src/entity/post_reply.entity.ts
@@ -17,6 +17,9 @@ export class PostReply {
   @Column({ name: 'content', nullable: false, length: 300 })
   content!: string;
 
+  @Column({ name: 'heart_count', nullable: false })
+  heartCount!: number;
+
   @Column({ name: 'deleted_at', type: 'timestamp', nullable: true })
   deletedAt?: Date;
 

--- a/src/entity/post_reply_heart.entity.ts
+++ b/src/entity/post_reply_heart.entity.ts
@@ -1,6 +1,6 @@
 import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 
-@Entity({ name: 'Post_reply_heart' })
+@Entity({ name: 'post_reply_heart' })
 export class PostReplyHeart {
   @PrimaryGeneratedColumn()
   id!: number;

--- a/src/repository/feed-comment.query-repository.ts
+++ b/src/repository/feed-comment.query-repository.ts
@@ -24,6 +24,11 @@ export class FeedCommentQueryRepository {
         'feedCommentHeart',
         'feedComment.id = feedCommentHeart.commentId AND feedCommentHeart.memberId = :memberId',
       )
+      .leftJoin(
+        FeedReply,
+        'feed_reply',
+        'feed_reply.comment_id = feedComment.id'
+      )
       .select([
         'member.id as writerId',
         'member.nickname as nickname',
@@ -35,7 +40,9 @@ export class FeedCommentQueryRepository {
         'CASE WHEN ISNULL(feedCommentHeart.id) THEN false ELSE true END as isHearted',
         'feedComment.createdAt as createdAt',
         'CASE WHEN feedComment.member_id = :memberId THEN 1 ELSE 0 END as isMine',
+        'CASE WHEN feed_reply.id IS NOT NULL THEN true ELSE false END as isReplied',
       ])
+      .groupBy('feedComment.id')
       .limit(paginationRequest.take)
       .offset(paginationRequest.getSkip())
       .orderBy('feedComment.createdAt', paginationRequest.order)
@@ -131,6 +138,8 @@ export class GetFeedCommentTuple {
   createdAt: Date;
   @Transform(({ value }) => Boolean(value))
   isMine: boolean;
+  @Transform(({ value }) => Boolean(value))
+  isReplied: boolean;
 }
 
 export class GetFeedReplyTuple {

--- a/src/repository/post-comment.query-repository.ts
+++ b/src/repository/post-comment.query-repository.ts
@@ -5,11 +5,13 @@ import { PaginationRequest } from 'src/common/pagination/pagination-request';
 import { Member } from 'src/entity/member.entity';
 import { PostComment } from 'src/entity/post_comment.entity';
 import { PostCommentHeart } from 'src/entity/post_comment_heart.entity';
+import { PostReply } from 'src/entity/post_reply.entity';
+import { PostReplyHeart } from 'src/entity/post_reply_heart.entity';
 import { DataSource } from 'typeorm';
 
 @Injectable()
 export class PostCommentQueryRepository {
-  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) { }
 
   async getPostCommentList(
     postId: number,
@@ -56,6 +58,52 @@ export class PostCommentQueryRepository {
       .andWhere('member.deletedAt IS NULL')
       .andWhere('post_comment.post_id = :postId', { postId });
   }
+
+  async getPostReplyList(
+    commentId: number,
+    memberId: number,
+    paginationRequest: PaginationRequest,
+  ): Promise<GetPostReplyTuple[]> {
+    const postReplyList = await this.getPostReplyListBaseQuery(commentId)
+      .leftJoin(
+        PostReplyHeart,
+        'post_reply_heart',
+        'post_reply_heart.reply_id = post_reply.id AND post_reply_heart.member_id = :memberId',
+      )
+      .select([
+        'member.id as memberId',
+        'member.nickname as nickname',
+        'member.generation as generation',
+        'member.profile_image_url as profileImageUrl',
+        'post_reply.id as replyId',
+        'post_reply.content as content',
+        'post_reply.heart_count as heartCount',
+        'post_reply.created_at as createdAt',
+        'CASE WHEN post_reply_heart.id IS NOT NULL THEN true ELSE false END as isHearted',
+        'CASE WHEN post_reply.member_id = :memberId THEN 1 ELSE 0 END as isMine',
+      ])
+      .limit(paginationRequest.take)
+      .offset(paginationRequest.getSkip())
+      .orderBy('post_reply.createdAt', paginationRequest.order)
+      .setParameters({ memberId })
+      .getRawMany();
+
+    return plainToInstance(GetPostReplyTuple, postReplyList);
+  }
+
+  async getPostReplyListCount(commentId: number): Promise<number> {
+    return await this.getPostReplyListBaseQuery(commentId).getCount();
+  }
+
+  private getPostReplyListBaseQuery(commentId: number) {
+    return this.dataSource
+      .createQueryBuilder()
+      .from(PostReply, 'post_reply')
+      .innerJoin(Member, 'member', 'post_reply.member_id = member.id')
+      .where('post_reply.deletedAt IS NULL')
+      .andWhere('member.deletedAt IS NULL')
+      .andWhere('post_reply.comment_id = :commentId', { commentId });
+  }
 }
 
 export class GetPostCommentTuple {
@@ -64,6 +112,21 @@ export class GetPostCommentTuple {
   generation: number;
   profileImageUrl: string;
   commentId: number;
+  content: string;
+  heartCount: number;
+  createdAt: Date;
+  @Transform(({ value }) => Boolean(value))
+  isHearted: boolean;
+  @Transform(({ value }) => Boolean(value))
+  isMine: boolean;
+}
+
+export class GetPostReplyTuple {
+  memberId: number;
+  nickname: string;
+  generation: number;
+  profileImageUrl: string;
+  replyId: number;
   content: string;
   heartCount: number;
   createdAt: Date;

--- a/src/repository/post-comment.query-repository.ts
+++ b/src/repository/post-comment.query-repository.ts
@@ -24,6 +24,11 @@ export class PostCommentQueryRepository {
         'post_comment_heart',
         'post_comment_heart.comment_id = post_comment.id AND post_comment_heart.member_id = :memberId',
       )
+      .leftJoin(
+        PostReply,
+        'post_reply',
+        'post_reply.comment_id = post_comment.id'
+      )
       .select([
         'member.id as memberId',
         'member.nickname as nickname',
@@ -35,7 +40,9 @@ export class PostCommentQueryRepository {
         'post_comment.created_at as createdAt',
         'CASE WHEN post_comment_heart.id IS NOT NULL THEN true ELSE false END as isHearted',
         'CASE WHEN post_comment.member_id = :memberId THEN 1 ELSE 0 END as isMine',
+        'CASE WHEN post_reply.id IS NOT NULL THEN true ELSE false END as isReplied'
       ])
+      .groupBy('post_comment.id')
       .limit(paginationRequest.take)
       .offset(paginationRequest.getSkip())
       .orderBy('post_comment.createdAt', paginationRequest.order)
@@ -119,6 +126,8 @@ export class GetPostCommentTuple {
   isHearted: boolean;
   @Transform(({ value }) => Boolean(value))
   isMine: boolean;
+  @Transform(({ value }) => Boolean(value))
+  isReplied: boolean;
 }
 
 export class GetPostReplyTuple {

--- a/src/service/feed-comment.service.ts
+++ b/src/service/feed-comment.service.ts
@@ -28,7 +28,7 @@ export class FeedCommentService {
     private readonly memberQueryRepository: MemberQueryRepository,
     private readonly memberDomainService: MemberDomainService,
     private readonly notificationDomainService: NotificationDomainService,
-  ) {}
+  ) { }
 
   async getFeedCommentList(
     feedId: number,
@@ -58,6 +58,7 @@ export class FeedCommentService {
         isHearted: item.isHearted,
         createdAt: item.createdAt,
         isMine: item.isMine,
+        isReplied: item.isReplied,
       };
 
       return GetFeedCommentResponseDto.from({ writer, comment });
@@ -186,4 +187,5 @@ export class FeedCommentDto {
   isHearted: boolean;
   createdAt: Date;
   isMine: boolean;
+  isReplied: boolean;
 }

--- a/src/service/feed-reply.service.ts
+++ b/src/service/feed-reply.service.ts
@@ -1,14 +1,18 @@
 import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { PaginationRequest } from 'src/common/pagination/pagination-request';
 import { FeedDomainService } from 'src/domain-service/feed.domain-service';
+import { GetFeedReplyList } from 'src/dto/get-feed-reply-list.dto';
 import { FeedComment } from 'src/entity/feed_comment.entity';
 import { FeedReply } from 'src/entity/feed_reply.entity';
+import { FeedCommentQueryRepository } from 'src/repository/feed-comment.query-repository';
 import { Repository } from 'typeorm';
 
 @Injectable()
 export class FeedReplyService {
   constructor(
     private readonly feedDomainService: FeedDomainService,
+    private readonly feedCommentQueryRepository: FeedCommentQueryRepository,
     @InjectRepository(FeedComment) private readonly feedCommentRepository: Repository<FeedComment>,
     @InjectRepository(FeedReply) private readonly feedReplyRepository: Repository<FeedReply>,
   ) { }
@@ -42,7 +46,7 @@ export class FeedReplyService {
     replyInfo.setFeedReplyContent(content);
     await this.feedReplyRepository.save(replyInfo);
   }
-  
+
   async deleteFeedReply(feedId: number, replyId: number, memberId: number): Promise<void> {
     await this.feedDomainService.getFeedIsNotDeleted(feedId);
     const replyInfo = await this.feedReplyRepository.findOneBy({ id: replyId, feedId });
@@ -58,4 +62,27 @@ export class FeedReplyService {
     await this.feedReplyRepository.save(replyInfo);
 
   }
+
+  async getFeedReplyList(commentId: number, memberId: number, paginationRequest: PaginationRequest) {
+    const feedReplyList = await this.feedCommentQueryRepository.getFeedReplyList(commentId, memberId, paginationRequest);
+    const totalCount = await this.feedCommentQueryRepository.getFeedReplyListCount(commentId);
+    const feedReplyInfo = feedReplyList.map((replyList) => GetFeedReplyList.from(replyList));
+    return { feedReplyInfo, totalCount };
+  }
+}
+
+export class FeedReplyWriterDto {
+  id: number;
+  nickname: string;
+  generation: number;
+  profileImageUrl: string;
+}
+
+export class FeedReplyDto {
+  id: number;
+  content: string;
+  heartCount: number;
+  isHearted: boolean;
+  createdAt: Date;
+  isMine: boolean;
 }

--- a/src/service/post-reply.service.ts
+++ b/src/service/post-reply.service.ts
@@ -1,14 +1,18 @@
 import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { PaginationRequest } from 'src/common/pagination/pagination-request';
 import { PostDomainService } from 'src/domain-service/post.domain-service';
+import { GetPostReplyList } from 'src/dto/get-post-reply-list.dto';
 import { PostComment } from 'src/entity/post_comment.entity';
 import { PostReply } from 'src/entity/post_reply.entity';
+import { PostCommentQueryRepository } from 'src/repository/post-comment.query-repository';
 import { Repository } from 'typeorm';
 
 @Injectable()
 export class PostReplyService {
   constructor(
     private readonly postDomainService: PostDomainService,
+    private readonly postCommentQueryRepository: PostCommentQueryRepository,
     @InjectRepository(PostComment) private readonly postCommentRepository: Repository<PostComment>,
     @InjectRepository(PostReply) private readonly postReplyRepository: Repository<PostReply>,
   ) { }
@@ -59,4 +63,27 @@ export class PostReplyService {
     await this.postReplyRepository.save(replyInfo);
 
   }
+
+  async getPostReplyList(commentId: number, memberId: number, paginationRequest: PaginationRequest) {
+    const postReplyList = await this.postCommentQueryRepository.getPostReplyList(commentId, memberId, paginationRequest);
+    const totalCount = await this.postCommentQueryRepository.getPostReplyListCount(commentId);
+    const postReplyInfo = postReplyList.map((replyList) => GetPostReplyList.from(replyList));
+    return { postReplyInfo, totalCount };
+  }
+}
+
+export class PostReplyWriterDto {
+  id: number;
+  nickname: string;
+  generation: number;
+  profileImageUrl: string;
+}
+
+export class PostReplyDto {
+  id: number;
+  content: string;
+  heartCount: number;
+  isHearted: boolean;
+  createdAt: Date;
+  isMine: boolean;
 }

--- a/src/service/post.service.ts
+++ b/src/service/post.service.ts
@@ -464,4 +464,5 @@ export class PostCommentDto {
   isHearted: boolean;
   createdAt: Date;
   isMine: boolean;
+  isReplied: boolean;
 }


### PR DESCRIPTION
### 개요  
**피드 / 포스트에 대댓글 조회 API를 추가하였습니다.**
### 예상 리뷰시간  
10분
### 상세내용
- 댓글 id로 대댓글을 조회할 수 있습니다.
- 페이지네이션 방식으로 내려갑니다.
- 댓글 응답에 대댓글이 있는지 확인하는 isReplied를 추가하였습니다.
### 특이사항
대댓글 좋아요, 대댓글 좋아요 취소 api가 남은 것 같네요..!